### PR TITLE
Using black format standards for all python files

### DIFF
--- a/libs/Helpers.py
+++ b/libs/Helpers.py
@@ -4,22 +4,23 @@ from robotlibcore import keyword
 
 class Helpers:
     """Custom keywords written in Python"""
+
     @keyword
     def text_to_list(self, text):
-        rows = text.split('\n')
+        rows = text.split("\n")
         print(rows)
         return rows
 
     @keyword
     def gte(self, version, target):
-        """ Returns True if the SemVer version >= target
-            and otherwise False including if an exception is thrown """
+        """Returns True if the SemVer version >= target
+        and otherwise False including if an exception is thrown"""
         try:
-            version=VersionInfo.parse(version)
-            target=VersionInfo.parse(target)
-            #version=tuple(version.translate(str.maketrans('', '', string.punctuation)))
-            #target=tuple(target.translate(str.maketrans('', '', string.punctuation)))
-            return version>=target
+            version = VersionInfo.parse(version)
+            target = VersionInfo.parse(target)
+            # version=tuple(version.translate(str.maketrans('', '', string.punctuation)))
+            # target=tuple(target.translate(str.maketrans('', '', string.punctuation)))
+            return version >= target
         except ValueError:
             # Returning False on exception as a workaround for when an null (or invalid) semver version is passed
             return False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 robotframework-lsp
 robotframework-robocop
 robotframework-tidy
+black

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "requests",
         "robotframework-requests",
         "escapism",
-        "semver>=2,<3"
+        "semver>=2,<3",
     ],
     zip_safe=True,
     include_package_data=True,

--- a/temp/Resources/Page/ODH/JupyterHub/jupyter-helper.py
+++ b/temp/Resources/Page/ODH/JupyterHub/jupyter-helper.py
@@ -7,4 +7,4 @@ def get_safe_username(username):
     # Kubespawner example:
     #  https://github.com/jupyterhub/kubespawner/blob/251a0b65ffaff72e722446d5b9aac738ad6923d1/kubespawner/spawner.py#L1709
     safe_chars = set(string.ascii_lowercase + string.digits)
-    return escapism.escape(username, safe=safe_chars, escape_char='-').lower()
+    return escapism.escape(username, safe=safe_chars, escape_char="-").lower()

--- a/utils/scripts/logger.py
+++ b/utils/scripts/logger.py
@@ -2,20 +2,23 @@ import logging
 import logging.handlers
 import sys
 
-# Change root logger level from WARNING (default) to NOTSET in order for all messages to be delegated.
+# Change root logger level from WARNING (default) to NOTSET in order for all messages
+# to be delegated.
 logging.getLogger().setLevel(logging.NOTSET)
 
 # Add stdout handler, with level INFO
 console = logging.StreamHandler(sys.stdout)
 console.setLevel(logging.INFO)
-formater = logging.Formatter('%(name)-13s: %(levelname)-8s %(message)s')
+formater = logging.Formatter("%(name)-13s: %(levelname)-8s %(message)s")
 console.setFormatter(formater)
 logging.getLogger().addHandler(console)
 
 # Add file rotating handler, with level DEBUG
-rotatingHandler = logging.handlers.RotatingFileHandler(filename='rhoda-ci.log', maxBytes=1000, backupCount=5)
+rotatingHandler = logging.handlers.RotatingFileHandler(
+    filename="rhoda-ci.log", maxBytes=1000, backupCount=5
+)
 rotatingHandler.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 rotatingHandler.setFormatter(formatter)
 logging.getLogger().addHandler(rotatingHandler)
 

--- a/utils/scripts/ocm/ocm.py
+++ b/utils/scripts/ocm/ocm.py
@@ -10,9 +10,8 @@ import time
 import glob
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(dir_path+"/../")
-from util import (clone_config_repo, read_yaml,
-                  execute_command)
+sys.path.append(dir_path + "/../")
+from util import clone_config_repo, read_yaml, execute_command
 from logger import log
 
 """
@@ -20,7 +19,7 @@ Class for Openshift Cluster Manager
 """
 
 
-class OpenshiftClusterManager():
+class OpenshiftClusterManager:
     def __init__(self, args={}):
 
         # Initialize instance variables
@@ -52,10 +51,10 @@ class OpenshiftClusterManager():
         self.config_template = args.get("config_template")
         self.repo_dir = args.get("repo_dir")
 
-        ocm_env = glob.glob(dir_path+"/../../../ocm.json.*")
+        ocm_env = glob.glob(dir_path + "/../../../ocm.json.*")
         if ocm_env != []:
-            os.environ['OCM_CONFIG'] = ocm_env[0]
-            match = re.search(r'.*\.(\S+)', (os.path.basename(ocm_env[0])))
+            os.environ["OCM_CONFIG"] = ocm_env[0]
+            match = re.search(r".*\.(\S+)", (os.path.basename(ocm_env[0])))
             if match is not None:
                 self.testing_platform = match.group(1)
 
@@ -92,8 +91,7 @@ class OpenshiftClusterManager():
             cmd += " " + filter
         ret = execute_command(cmd)
         if ret is None:
-            log.info("ocm describe for cluster "
-                   "{} failed".format(self.cluster_name))
+            log.info("ocm describe for cluster " "{} failed".format(self.cluster_name))
             return None
         return ret
 
@@ -101,8 +99,9 @@ class OpenshiftClusterManager():
         """Checks if cluster exists"""
         ret = self.ocm_describe()
         if ret is None:
-            log.info("ocm cluster with name "
-                   "{} not exists!".format(self.cluster_name))
+            log.info(
+                "ocm cluster with name " "{} not exists!".format(self.cluster_name)
+            )
             return False
         log.info("ocm cluster with name {} exists!".format(self.cluster_name))
         return True
@@ -110,19 +109,25 @@ class OpenshiftClusterManager():
     def osd_cluster_create(self):
         """Creates OSD cluster"""
 
-        if ((self.channel_group == "candidate") and (self.testing_platform == "prod")):
-            log.error("Channel group 'candidate' is available only for stage environment.")
+        if (self.channel_group == "candidate") and (self.testing_platform == "prod"):
+            log.error(
+                "Channel group 'candidate' is available only for stage environment."
+            )
             sys.exit(1)
 
         version = ""
         if self.openshift_version != "":
-            version_match = re.match(r'(\d+\.\d+)\-latest',self.openshift_version)
+            version_match = re.match(r"(\d+\.\d+)\-latest", self.openshift_version)
             if version_match is not None:
                 version = version_match.group(1)
                 chan_grp = ""
-                if (self.channel_group == "candidate"):
+                if self.channel_group == "candidate":
                     chan_grp = "--channel-group {}".format(self.channel_group)
-                version_cmd = "ocm list versions {} | grep -w \"".format(chan_grp) + re.escape(version) + "*\""
+                version_cmd = (
+                    'ocm list versions {} | grep -w "'.format(chan_grp)
+                    + re.escape(version)
+                    + '*"'
+                )
                 log.info("CMD: {}".format(version_cmd))
                 versions = execute_command(version_cmd)
                 if versions is not None:
@@ -135,26 +140,39 @@ class OpenshiftClusterManager():
             log.info("Using the latest osd version available in AWS...")
 
         channel_grp = ""
-        if (self.channel_group != ""):
-            if ((self.channel_group == "stable") or (self.channel_group == "candidate")):
+        if self.channel_group != "":
+            if (self.channel_group == "stable") or (self.channel_group == "candidate"):
                 if version == "":
-                    log.error(("Please enter openshift version as argument."
-                               "Channel group option is used along with openshift version."))
+                    log.error(
+                        (
+                            "Please enter openshift version as argument."
+                            "Channel group option is used along with openshift version."
+                        )
+                    )
                     sys.exit(1)
                 else:
                     channel_grp = "--channel-group {} ".format(self.channel_group)
             else:
-                log.error("Invalid channel group. Values can be 'stable' or 'candidate'.")
-        cmd = ("ocm create cluster --aws-account-id {} "
-               "--aws-access-key-id {} --aws-secret-access-key {} "
-               "--ccs --region {} --compute-nodes {} "
-               "--compute-machine-type {} {} {}"
-               "{}".format(self.aws_account_id,
-                           self.aws_access_key_id,
-                           self.aws_secret_access_key,
-                           self.aws_region, self.num_compute_nodes,
-                           self.aws_instance_type, version,
-                           channel_grp, self.cluster_name))
+                log.error(
+                    "Invalid channel group. Values can be 'stable' or 'candidate'."
+                )
+        cmd = (
+            "ocm create cluster --aws-account-id {} "
+            "--aws-access-key-id {} --aws-secret-access-key {} "
+            "--ccs --region {} --compute-nodes {} "
+            "--compute-machine-type {} {} {}"
+            "{}".format(
+                self.aws_account_id,
+                self.aws_access_key_id,
+                self.aws_secret_access_key,
+                self.aws_region,
+                self.num_compute_nodes,
+                self.aws_instance_type,
+                version,
+                channel_grp,
+                self.cluster_name,
+            )
+        )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
@@ -166,8 +184,10 @@ class OpenshiftClusterManager():
 
         cluster_name = self.ocm_describe(filter="--json | jq -r '.id'")
         if cluster_name is None:
-            log.info("Unable to retrieve cluster ID for "
-                     "cluster name {}. EXITING".format(self.cluster_name))
+            log.info(
+                "Unable to retrieve cluster ID for "
+                "cluster name {}. EXITING".format(self.cluster_name)
+            )
             sys.exit(1)
         return cluster_name.strip("\n")
 
@@ -176,8 +196,10 @@ class OpenshiftClusterManager():
 
         cluster_state = self.ocm_describe(filter="--json | jq -r '.state'")
         if cluster_state is None:
-            log.info("Unable to retrieve cluster state for "
-                   "cluster name {}. EXITING".format(self.cluster_name))
+            log.info(
+                "Unable to retrieve cluster state for "
+                "cluster name {}. EXITING".format(self.cluster_name)
+            )
             sys.exit(1)
         return cluster_state.strip("\n")
 
@@ -186,8 +208,10 @@ class OpenshiftClusterManager():
 
         cluster_version = self.ocm_describe(filter="--json | jq -r '.version.raw_id'")
         if cluster_version is None:
-            log.info("Unable to retrieve cluster version for "
-                   "cluster name {}. EXITING".format(self.cluster_name))
+            log.info(
+                "Unable to retrieve cluster version for "
+                "cluster name {}. EXITING".format(self.cluster_name)
+            )
             sys.exit(1)
         return cluster_version.strip("\n")
 
@@ -197,8 +221,10 @@ class OpenshiftClusterManager():
         filter_str = "--json | jq -r '.console.url'"
         cluster_console_url = self.ocm_describe(filter=filter_str)
         if cluster_console_url is None:
-            log.info("Unable to retrieve cluster console url "
-                   "for cluster name {}. EXITING".format(self.cluster_name))
+            log.info(
+                "Unable to retrieve cluster console url "
+                "for cluster name {}. EXITING".format(self.cluster_name)
+            )
             sys.exit(1)
         return cluster_console_url.strip("\n")
 
@@ -207,34 +233,38 @@ class OpenshiftClusterManager():
         config_template = self.repo_dir + self.config_template
         shutil.copy(config_template, self.repo_dir + "test-variables.yaml")
         config_file = self.repo_dir + "test-variables.yaml"
-        with open(config_file, 'r') as fh:
+        with open(config_file, "r") as fh:
             data = yaml.safe_load(fh)
         console_url = self.get_osd_cluster_console_url()
-        data['OCP_CONSOLE_URL'] = console_url
+        data["OCP_CONSOLE_URL"] = console_url
         cluster_version = self.get_osd_cluster_version()
-        data['CLUSTER_VERSION'] = cluster_version
-        data['OCP_ADMIN_USER'] = {}
-        data['OCP_ADMIN_USER']['AUTH_TYPE'] = "htpasswd-cluster-admin"
-        data['OCP_ADMIN_USER']['USERNAME'] = "htpasswd-cluster-admin-user"
-        data['OCP_ADMIN_USER']['PASSWORD'] = self.htpasswd_cluster_password
-        with open(config_file, 'w') as yaml_file:
+        data["CLUSTER_VERSION"] = cluster_version
+        data["OCP_ADMIN_USER"] = {}
+        data["OCP_ADMIN_USER"]["AUTH_TYPE"] = "htpasswd-cluster-admin"
+        data["OCP_ADMIN_USER"]["USERNAME"] = "htpasswd-cluster-admin-user"
+        data["OCP_ADMIN_USER"]["PASSWORD"] = self.htpasswd_cluster_password
+        with open(config_file, "w") as yaml_file:
             yaml_file.write(yaml.dump(data, default_flow_style=False, sort_keys=False))
         log.info("success!")
 
     def update_osd_cluster_info(self, config_file="rhoda_config_file.yaml"):
         """Updates osd cluster information and stores in config file"""
 
-        with open(config_file, 'r') as file:
+        with open(config_file, "r") as file:
             config_data = yaml.load(file)
 
         if self.ldap_test_password != "":
-            config_data[self.cluster_name]['TEST_USER']['PASSWORD'] = self.ldap_test_password
+            config_data[self.cluster_name]["TEST_USER"][
+                "PASSWORD"
+            ] = self.ldap_test_password
 
         if self.htpasswd_cluster_password != "":
-            config_data[self.cluster_name]['OCP_ADMIN_USER']['PASSWORD'] = self.htpasswd_cluster_password
+            config_data[self.cluster_name]["OCP_ADMIN_USER"][
+                "PASSWORD"
+            ] = self.htpasswd_cluster_password
 
-        with open(config_file, 'w') as yaml_file:
-            yaml_file.write( yaml.dump(config_data, default_flow_style=False))
+        with open(config_file, "w") as yaml_file:
+            yaml_file.write(yaml.dump(config_data, default_flow_style=False))
 
     def wait_for_osd_cluster_to_be_ready(self, timeout=7200):
         """Waits for cluster to be in ready state"""
@@ -243,22 +273,25 @@ class OpenshiftClusterManager():
         cluster_state = self.get_osd_cluster_state()
         count = 0
         check_flag = False
-        while(count <= timeout):
+        while count <= timeout:
             cluster_state = self.get_osd_cluster_state()
             if cluster_state == "ready":
                 log.info("{} is in ready state".format(self.cluster_name))
                 check_flag = True
                 break
             elif cluster_state == "error":
-                log.info("{} is in error state. Hence "
-                       "exiting!!".format(self.cluster_name))
+                log.info(
+                    "{} is in error state. Hence " "exiting!!".format(self.cluster_name)
+                )
                 sys.exit(1)
 
             time.sleep(60)
             count += 60
         if not check_flag:
-            log.info("{} not in ready state even after 2 hours."
-                   " EXITING".format(self.cluster_name))
+            log.info(
+                "{} not in ready state even after 2 hours."
+                " EXITING".format(self.cluster_name)
+            )
             sys.exit(1)
 
     def _render_template(self, template_file, output_file, replace_vars):
@@ -266,16 +299,18 @@ class OpenshiftClusterManager():
 
         try:
             templateLoader = jinja2.FileSystemLoader(
-                searchpath=os.path.abspath(
-                    os.path.dirname(__file__)) + "/templates")
+                searchpath=os.path.abspath(os.path.dirname(__file__)) + "/templates"
+            )
             templateEnv = jinja2.Environment(loader=templateLoader)
             template = templateEnv.get_template(template_file)
             outputText = template.render(replace_vars)
-            with open(output_file, 'w') as fh:
+            with open(output_file, "w") as fh:
                 fh.write(outputText)
         except:
-            log.info("Failed to render template and create json "
-                   "file {}".format(output_file))
+            log.info(
+                "Failed to render template and create json "
+                "file {}".format(output_file)
+            )
             sys.exit(1)
 
     def is_addon_installed(self, addon_name="managed-odh"):
@@ -283,24 +318,31 @@ class OpenshiftClusterManager():
 
         addon_state = self.get_addon_state(addon_name)
         if addon_state == "not installed":
-            log.info("Addon {} not installed in cluster "
-                   "{}".format(addon_name, self.cluster_name))
+            log.info(
+                "Addon {} not installed in cluster "
+                "{}".format(addon_name, self.cluster_name)
+            )
             return False
-        log.info("Addon {} is installed in cluster"
-               " {}".format(addon_name, self.cluster_name))
+        log.info(
+            "Addon {} is installed in cluster"
+            " {}".format(addon_name, self.cluster_name)
+        )
         return True
 
     def get_addon_state(self, addon_name="managed-odh"):
         """Gets given addon's state"""
 
-        cmd = ("ocm list addons --cluster {} --columns id,state | grep "
-               "{} ".format(self.cluster_name, addon_name))
+        cmd = "ocm list addons --cluster {} --columns id,state | grep " "{} ".format(
+            self.cluster_name, addon_name
+        )
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to get {} addon state for cluster "
-                   "{}".format(addon_name, self.cluster_name))
+            log.info(
+                "Failed to get {} addon state for cluster "
+                "{}".format(addon_name, self.cluster_name)
+            )
             return None
-        match = re.search(addon_name+'\s*(.*)', ret)
+        match = re.search(addon_name + "\s*(.*)", ret)
         if match is None:
             log.info("regex failed in get_addon_state")
             return None
@@ -308,13 +350,18 @@ class OpenshiftClusterManager():
 
     def add_machine_pool(self):
         """Adds machine pool to the given cluster"""
-        cmd = ("ocm create machinepool --cluster {} "
-               "--instance-type {} --replicas {} "
-               "--taints {} "
-               "{}".format(self.cluster_name,
-                           self.pool_instance_type,
-                           self.pool_node_count, self.taints,
-                           self.pool_name))
+        cmd = (
+            "ocm create machinepool --cluster {} "
+            "--instance-type {} --replicas {} "
+            "--taints {} "
+            "{}".format(
+                self.cluster_name,
+                self.pool_instance_type,
+                self.pool_node_count,
+                self.taints,
+                self.pool_name,
+            )
+        )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
@@ -322,14 +369,15 @@ class OpenshiftClusterManager():
             sys.exit(1)
         time.sleep(60)
 
-    def wait_for_addon_installation_to_complete(self, addon_name="managed-odh",
-                                                timeout=3600):
+    def wait_for_addon_installation_to_complete(
+        self, addon_name="managed-odh", timeout=3600
+    ):
         """Waits for addon installation to get complete"""
 
         addon_state = self.get_addon_state(addon_name)
         count = 0
         check_flag = False
-        while(count <= timeout):
+        while count <= timeout:
             addon_state = self.get_addon_state(addon_name)
             if addon_state == "ready":
                 log.info("addon {} is in installed state".format(addon_name))
@@ -339,18 +387,21 @@ class OpenshiftClusterManager():
             time.sleep(60)
             count += 60
         if not check_flag:
-            log.info("addon {} not in installed state even after "
-                   "60 minutes. EXITING".format(addon_name))
+            log.info(
+                "addon {} not in installed state even after "
+                "60 minutes. EXITING".format(addon_name)
+            )
             sys.exit(1)
 
-    def wait_for_addon_uninstallation_to_complete(self, addon_name="managed-odh",
-                                                  timeout=3600):
+    def wait_for_addon_uninstallation_to_complete(
+        self, addon_name="managed-odh", timeout=3600
+    ):
         """Waits for addon uninstallation to get complete"""
 
         addon_state = self.get_addon_state(addon_name)
         count = 0
         check_flag = False
-        while(count <= timeout):
+        while count <= timeout:
             addon_state = self.get_addon_state(addon_name)
             if addon_state == "not installed":
                 log.info("addon {} is in uninstalled state".format(addon_name))
@@ -360,20 +411,21 @@ class OpenshiftClusterManager():
             time.sleep(60)
             count += 60
         if not check_flag:
-            log.info("addon {} not in uninstalled state even after "
-                   "60 minutes. EXITING".format(addon_name))
+            log.info(
+                "addon {} not in uninstalled state even after "
+                "60 minutes. EXITING".format(addon_name)
+            )
             sys.exit(1)
 
     def list_idps(self):
         """Lists IDPs for the cluster"""
 
-        cmd = ("ocm list idps --cluster {} --columns name"
-               .format(self.cluster_name))
+        cmd = "ocm list idps --cluster {} --columns name".format(self.cluster_name)
         ret = execute_command(cmd)
         if ret is None:
             return []
         if ret != []:
-            ret = ret.split('\n')[1:-1]
+            ret = ret.split("\n")[1:-1]
         return ret
 
     def is_idp_exists(self, idp_name):
@@ -386,22 +438,22 @@ class OpenshiftClusterManager():
 
     def install_addon(self, addon_name="managed-odh"):
         """Installs addon"""
-        replace_vars = {
-                       "CLUSTER_ID": self.cluster_name,
-                       "ADDON_NAME": addon_name
-                       }
+        replace_vars = {"CLUSTER_ID": self.cluster_name, "ADDON_NAME": addon_name}
         template_file = "install_addon.jinja"
         output_file = "install_operator.json"
         self._render_template(template_file, output_file, replace_vars)
 
         cluster_id = self.get_osd_cluster_id()
-        cmd = ("ocm post /api/clusters_mgmt/v1/clusters/{}/addons "
-               "--body={}".format(cluster_id, output_file))
+        cmd = "ocm post /api/clusters_mgmt/v1/clusters/{}/addons " "--body={}".format(
+            cluster_id, output_file
+        )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to install {} addon on cluster "
-                  "{}".format(addon_name, self.cluster_name))
+            log.info(
+                "Failed to install {} addon on cluster "
+                "{}".format(addon_name, self.cluster_name)
+            )
             sys.exit(1)
 
     def uninstall_addon(self, addon_name="managed-odh"):
@@ -410,13 +462,16 @@ class OpenshiftClusterManager():
         addon_state = self.get_addon_state(addon_name)
         if addon_state != "not installed":
             cluster_id = self.get_osd_cluster_id()
-            cmd = ("ocm delete /api/clusters_mgmt/v1/clusters/{}/addons/"
-                   "{}".format(cluster_id, addon_name))
+            cmd = "ocm delete /api/clusters_mgmt/v1/clusters/{}/addons/" "{}".format(
+                cluster_id, addon_name
+            )
             log.info("CMD: {}".format(cmd))
             ret = execute_command(cmd)
             if ret is None:
-                log.info("Failed to uninstall {} addon on cluster "
-                      "{}".format(addon_name, self.cluster_name))
+                log.info(
+                    "Failed to uninstall {} addon on cluster "
+                    "{}".format(addon_name, self.cluster_name)
+                )
                 sys.exit(1)
 
     def install_rhods(self):
@@ -431,23 +486,30 @@ class OpenshiftClusterManager():
         """Creates Identity Provider"""
 
         if self.idp_type == "htpasswd":
-            cmd = ("ocm create idp -c {} -t {} -n {} --username {} "
-                   "--password {}".format(self.cluster_name,
-                                          self.idp_type,
-                                          self.idp_name,
-                                          self.htpasswd_cluster_admin,
-                                          self.htpasswd_cluster_password))
+            cmd = (
+                "ocm create idp -c {} -t {} -n {} --username {} "
+                "--password {}".format(
+                    self.cluster_name,
+                    self.idp_type,
+                    self.idp_name,
+                    self.htpasswd_cluster_admin,
+                    self.htpasswd_cluster_password,
+                )
+            )
             log.info("CMD: {}".format(cmd))
             ret = execute_command(cmd)
             if ret is None:
-                log.info("Failed to add identity provider of "
-                      "type {}".format(self.idp_type))
+                log.info(
+                    "Failed to add identity provider of "
+                    "type {}".format(self.idp_type)
+                )
             self.add_user_to_group()
 
-        elif (self.idp_type == "ldap"):
-            ldap_yaml_file = (os.path.abspath(
-                os.path.dirname(__file__)) +
-                "/../../../configs/templates/ldap/ldap.yaml")
+        elif self.idp_type == "ldap":
+            ldap_yaml_file = (
+                os.path.abspath(os.path.dirname(__file__))
+                + "/../../../configs/templates/ldap/ldap.yaml"
+            )
             cmd = "oc apply -f {}".format(ldap_yaml_file)
             log.info("CMD: {}".format(cmd))
             ret = execute_command(cmd)
@@ -456,18 +518,20 @@ class OpenshiftClusterManager():
                 sys.exit(1)
 
             replace_vars = {
-                           "LDAP_URL": self.ldap_url,
-                           "LDAP_BIND_DN": self.ldap_bind_dn,
-                           "LDAP_BIND_PASSWORD": self.ldap_bind_password
-                           }
+                "LDAP_URL": self.ldap_url,
+                "LDAP_BIND_DN": self.ldap_bind_dn,
+                "LDAP_BIND_PASSWORD": self.ldap_bind_password,
+            }
             template_file = "create_ldap_idp.jinja"
             output_file = "create_ldap_idp.json"
             self._render_template(template_file, output_file, replace_vars)
 
             cluster_id = self.get_osd_cluster_id()
-            cmd = ("ocm post /api/clusters_mgmt/v1/"
-                   "clusters/{}/identity_providers "
-                   "--body={}".format(cluster_id, output_file))
+            cmd = (
+                "ocm post /api/clusters_mgmt/v1/"
+                "clusters/{}/identity_providers "
+                "--body={}".format(cluster_id, output_file)
+            )
             log.info("CMD: {}".format(cmd))
             ret = execute_command(cmd)
             if ret is None:
@@ -478,13 +542,13 @@ class OpenshiftClusterManager():
     def delete_idp(self):
         """Deletes Identity Provider"""
 
-        cmd = ("ocm delete idp -c {} {}".format(self.cluster_name,
-                                                self.idp_name))
+        cmd = "ocm delete idp -c {} {}".format(self.cluster_name, self.idp_name)
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to delete identity provider of "
-                  "type {}".format(self.idp_name))
+            log.info(
+                "Failed to delete identity provider of " "type {}".format(self.idp_name)
+            )
 
     def add_user_to_group(self, user="", group="cluster-admins"):
         """Adds user to given group"""
@@ -492,19 +556,20 @@ class OpenshiftClusterManager():
         if user == "":
             user = self.htpasswd_cluster_admin
 
-        if ((group == "rhods-admins") or
-           (group == "rhods-users") or
-           (group == "rhods-noaccess")):
+        if (
+            (group == "rhods-admins")
+            or (group == "rhods-users")
+            or (group == "rhods-noaccess")
+        ):
             cmd = "oc adm groups add-users {} {}".format(group, user)
         else:
-            cmd = ("ocm create user {} --cluster {} "
-                   "--group={}".format(user,
-                                       self.cluster_name, group))
+            cmd = "ocm create user {} --cluster {} " "--group={}".format(
+                user, self.cluster_name, group
+            )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to add user {} to group "
-                  "{}".format(user, group))
+            log.info("Failed to add user {} to group " "{}".format(user, group))
 
     def create_group(self, group_name):
         """Creates new group"""
@@ -513,36 +578,33 @@ class OpenshiftClusterManager():
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to add group "
-                  "{}".format(group_name))
+            log.info("Failed to add group " "{}".format(group_name))
 
     def add_users_to_rhods_group(self):
         """Add users to rhods group"""
 
         self.create_group("rhods-admins")
         # Adds user ldap-admin1..ldap-adminN
-        for i in range(1, int(self.num_users_to_create_per_group)+1):
-            self.add_user_to_group(user="ldap-admin"+str(i),
-                                   group="rhods-admins")
+        for i in range(1, int(self.num_users_to_create_per_group) + 1):
+            self.add_user_to_group(user="ldap-admin" + str(i), group="rhods-admins")
 
         self.create_group("rhods-users")
         # Adds user ldap-user1..ldap-userN
-        for i in range(1, int(self.num_users_to_create_per_group)+1):
-            self.add_user_to_group(user="ldap-user"+str(i),
-                                   group="rhods-users")
+        for i in range(1, int(self.num_users_to_create_per_group) + 1):
+            self.add_user_to_group(user="ldap-user" + str(i), group="rhods-users")
 
-	# Adds special users
+        # Adds special users
         # "(", ")", "|", "<", ">" not working in OSD
         # "+" and ";" disabled for now
         for char in [".", "^", "$", "*", "?", "[", "]", "{", "}", "@"]:
-            self.add_user_to_group(user="ldap-special"+char,
-                                   group="rhods-users")
+            self.add_user_to_group(user="ldap-special" + char, group="rhods-users")
 
         self.create_group("rhods-noaccess")
         # Adds user ldap-noaccess1..ldap-noaccessN
-        for i in range(1, int(self.num_users_to_create_per_group)+1):
-            self.add_user_to_group(user="ldap-noaccess"+str(i),
-                                   group="rhods-noaccess")
+        for i in range(1, int(self.num_users_to_create_per_group) + 1):
+            self.add_user_to_group(
+                user="ldap-noaccess" + str(i), group="rhods-noaccess"
+            )
 
         # Logging users/groups details after adding
         # given user to group
@@ -578,7 +640,9 @@ class OpenshiftClusterManager():
     def install_gpu_addon(self):
         if not self.is_addon_installed(addon_name="gpu-operator-certified-addon"):
             self.install_addon(addon_name="gpu-operator-certified-addon")
-            self.wait_for_addon_installation_to_complete(addon_name="gpu-operator-certified-addon")
+            self.wait_for_addon_installation_to_complete(
+                addon_name="gpu-operator-certified-addon"
+            )
         # Waiting 5 minutes to ensure all the services are up
         time.sleep(300)
 
@@ -587,9 +651,9 @@ class OpenshiftClusterManager():
         self.wait_for_addon_uninstallation_to_complete()
 
     def ocm_login(self):
-        """ Login to OCM using ocm cli"""
+        """Login to OCM using ocm cli"""
 
-        cmd = "ocm login --token=\"{}\" ".format(self.token)
+        cmd = 'ocm login --token="{}" '.format(self.token)
 
         if self.testing_platform == "stage":
             cmd += "--url=staging"
@@ -600,10 +664,10 @@ class OpenshiftClusterManager():
         if ret is None:
             log.info("Failed to login to aws openshift platform using token")
             sys.exit(1)
-        os.environ["OCM_CONFIG"] =  "ocm.json." + self.testing_platform
+        os.environ["OCM_CONFIG"] = "ocm.json." + self.testing_platform
 
     def delete_cluster(self):
-        """ Delete OSD Cluster"""
+        """Delete OSD Cluster"""
 
         cluster_id = self.get_osd_cluster_id()
         cmd = "ocm delete cluster {}".format(cluster_id)
@@ -620,7 +684,7 @@ class OpenshiftClusterManager():
         cluster_exists = self.is_osd_cluster_exists()
         count = 0
         check_flag = False
-        while(count <= timeout):
+        while count <= timeout:
             cluster_exists = self.is_osd_cluster_exists()
             if not cluster_exists:
                 log.info("{} is deleted".format(self.cluster_name))
@@ -630,8 +694,10 @@ class OpenshiftClusterManager():
             time.sleep(60)
             count += 60
         if not check_flag:
-            log.info("{} not deleted even after an hour."
-                   " EXITING".format(self.cluster_name))
+            log.info(
+                "{} not deleted even after an hour."
+                " EXITING".format(self.cluster_name)
+            )
             sys.exit(1)
 
     def install_rhoda_addon(self):
@@ -649,339 +715,552 @@ class OpenshiftClusterManager():
         else:
             log.info("Operator is not installed on this cluster")
 
+
 if __name__ == "__main__":
+    # Instance for OpenshiftClusterManager Class
+    ocm_obj = OpenshiftClusterManager()
 
-        #Instance for OpenshiftClusterManager Class
-        ocm_obj = OpenshiftClusterManager()
+    """Parse CLI arguments"""
 
-        """Parse CLI arguments"""
+    ocm_cli_binary_url = (
+        "https://github.com/openshift-online/ocm-cli/"
+        "releases/download/v0.1.55/ocm-linux-amd64"
+    )
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Script to generate test config file",
+    )
 
-        ocm_cli_binary_url = ("https://github.com/openshift-online/ocm-cli/"
-                              "releases/download/v0.1.55/ocm-linux-amd64")
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            description='Script to generate test config file')
+    subparsers = parser.add_subparsers(
+        title="Available sub commands", help="sub-command help"
+    )
 
-        subparsers = parser.add_subparsers(title='Available sub commands',
-                                           help='sub-command help')
+    # Argument parsers for ocm_login
+    ocm_login_parser = subparsers.add_parser(
+        "ocm_login",
+        help=("Login to OCM using token"),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-        #Argument parsers for ocm_login
-        ocm_login_parser = subparsers.add_parser(
-            'ocm_login',
-            help=("Login to OCM using token"),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    optional_ocm_login_parser = ocm_login_parser._action_groups.pop()
+    required_ocm_login_parser = ocm_login_parser.add_argument_group(
+        "required arguments"
+    )
+    ocm_login_parser._action_groups.append(optional_ocm_login_parser)
+    required_ocm_login_parser.add_argument(
+        "--token",
+        help="openshift token for login",
+        action="store",
+        dest="token",
+        metavar="",
+        required=True,
+    )
+    optional_ocm_login_parser.add_argument(
+        "--testingplatform",
+        help="testing platform. 'prod' or 'stage'",
+        action="store",
+        dest="testing_platform",
+        metavar="",
+        default="stage",
+    )
+    ocm_login_parser.set_defaults(func=ocm_obj.ocm_login)
 
-        optional_ocm_login_parser = ocm_login_parser._action_groups.pop()
-        required_ocm_login_parser = ocm_login_parser.add_argument_group('required arguments')
-        ocm_login_parser._action_groups.append(optional_ocm_login_parser)
-        required_ocm_login_parser.add_argument("--token",
-            help="openshift token for login",
-            action="store", dest="token", metavar="",
-            required=True)
-        optional_ocm_login_parser.add_argument("--testingplatform",
-            help="testing platform. 'prod' or 'stage'",
-            action="store", dest="testing_platform", metavar="",
-            default="stage")
-        ocm_login_parser.set_defaults(func=ocm_obj.ocm_login)
+    # Argument parsers for create_cluster
+    create_cluster_parser = subparsers.add_parser(
+        "create_cluster",
+        help=("Create managed OpenShift Dedicated v4 clusters via OCM."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-        #Argument parsers for create_cluster
-        create_cluster_parser = subparsers.add_parser(
-            'create_cluster',
-            help=("Create managed OpenShift Dedicated v4 clusters via OCM."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    optional_create_cluster_parser = create_cluster_parser._action_groups.pop()
+    required_create_cluster_parser = create_cluster_parser.add_argument_group(
+        "required arguments"
+    )
+    create_cluster_parser._action_groups.append(optional_create_cluster_parser)
 
-        optional_create_cluster_parser = create_cluster_parser._action_groups.pop()
-        required_create_cluster_parser = create_cluster_parser.add_argument_group('required arguments')
-        create_cluster_parser._action_groups.append(optional_create_cluster_parser)
+    required_create_cluster_parser.add_argument(
+        "--aws-account-id",
+        help="aws account id",
+        action="store",
+        dest="aws_account_id",
+        required=True,
+    )
+    required_create_cluster_parser.add_argument(
+        "--aws-accesskey-id",
+        help="aws access key id",
+        action="store",
+        dest="aws_access_key_id",
+        required=True,
+    )
+    required_create_cluster_parser.add_argument(
+        "--aws-secret-accesskey",
+        help="aws secret access key",
+        action="store",
+        dest="aws_secret_access_key",
+        required=True,
+    )
 
-        required_create_cluster_parser.add_argument("--aws-account-id",
-            help="aws account id",
-            action="store", dest="aws_account_id",
-            required=True)
-        required_create_cluster_parser.add_argument("--aws-accesskey-id",
-            help="aws access key id",
-            action="store", dest="aws_access_key_id",
-            required=True)
-        required_create_cluster_parser.add_argument("--aws-secret-accesskey",
-            help="aws secret access key",
-            action="store", dest="aws_secret_access_key",
-            required=True)
+    optional_create_cluster_parser.add_argument(
+        "--cluster-name",
+        help="OSD cluster name",
+        action="store",
+        dest="cluster_name",
+        metavar="",
+        default="rhoda-qe-test",
+    )
+    optional_create_cluster_parser.add_argument(
+        "--aws-region",
+        help="aws region",
+        action="store",
+        dest="aws_region",
+        metavar="",
+        default="us-east-1",
+    )
+    optional_create_cluster_parser.add_argument(
+        "--aws-instance-type",
+        help="aws instance type",
+        action="store",
+        dest="aws_instance_type",
+        metavar="",
+        default="m5.2xlarge",
+    )
+    optional_create_cluster_parser.add_argument(
+        "--num-compute-nodes",
+        help="Number of compute nodes",
+        action="store",
+        dest="num_compute_nodes",
+        metavar="",
+        default="3",
+    )
+    optional_create_cluster_parser.add_argument(
+        "--openshift-version",
+        help="Openshift Version",
+        action="store",
+        dest="openshift_version",
+        metavar="",
+        default="",
+    )
+    optional_create_cluster_parser.add_argument(
+        "--channel-group",
+        help="Channel group name. Values can be stable or candidate.",
+        action="store",
+        dest="channel_group",
+        metavar="",
+        default="",
+    )
 
-        optional_create_cluster_parser.add_argument("--cluster-name",
-            help="OSD cluster name",
-            action="store", dest="cluster_name", metavar="",
-            default="rhoda-qe-test")
-        optional_create_cluster_parser.add_argument("--aws-region",
-            help="aws region",
-            action="store", dest="aws_region", metavar="",
-            default="us-east-1")
-        optional_create_cluster_parser.add_argument("--aws-instance-type",
-            help="aws instance type",
-            action="store", dest="aws_instance_type", metavar="",
-            default="m5.2xlarge")
-        optional_create_cluster_parser.add_argument("--num-compute-nodes",
-            help="Number of compute nodes",
-            action="store", dest="num_compute_nodes", metavar="",
-            default="3")
-        optional_create_cluster_parser.add_argument("--openshift-version",
-            help="Openshift Version",
-            action="store", dest="openshift_version",
-            metavar="", default="")
-        optional_create_cluster_parser.add_argument("--channel-group",
-            help="Channel group name. Values can be stable or candidate.",
-            action="store", dest="channel_group",
-            metavar="", default="")
+    create_cluster_parser.set_defaults(func=ocm_obj.create_cluster)
 
-        create_cluster_parser.set_defaults(func=ocm_obj.create_cluster)
+    # Argument parsers for delete_cluster
+    delete_cluster_parser = subparsers.add_parser(
+        "delete_cluster",
+        help=("Delete managed OpenShift Dedicated v4 clusters via OCM."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    delete_cluster_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        metavar="",
+        default="rhoda-qe-test",
+    )
+    delete_cluster_parser.set_defaults(func=ocm_obj.delete_cluster)
 
-        #Argument parsers for delete_cluster
-        delete_cluster_parser = subparsers.add_parser(
-            'delete_cluster',
-            help=("Delete managed OpenShift Dedicated v4 clusters via OCM."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        delete_cluster_parser.add_argument("--cluster-name",
-            help="osd cluster name",
-            action="store", dest="cluster_name", metavar="",
-            default="rhoda-qe-test")
-        delete_cluster_parser.set_defaults(func=ocm_obj.delete_cluster)
+    # Argument parsers for delete_idp
+    delete_idp_parser = subparsers.add_parser(
+        "delete_idp",
+        help=("Delete a specific identity provider for a cluster."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    optional_delete_idp_parser = delete_idp_parser._action_groups.pop()
+    required_delete_idp_parser = delete_idp_parser.add_argument_group(
+        "required arguments"
+    )
+    delete_idp_parser._action_groups.append(optional_delete_idp_parser)
+    required_delete_idp_parser.add_argument(
+        "--idp-name",
+        help="IDP name",
+        action="store",
+        dest="idp_name",
+        metavar="",
+        required=True,
+    )
+    optional_delete_idp_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        metavar="",
+        default="rhoda-qe-test",
+    )
+    delete_idp_parser.set_defaults(func=ocm_obj.delete_idp)
 
-        #Argument parsers for delete_idp
-        delete_idp_parser = subparsers.add_parser(
-            'delete_idp',
-            help=("Delete a specific identity provider for a cluster."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        optional_delete_idp_parser = delete_idp_parser._action_groups.pop()
-        required_delete_idp_parser = delete_idp_parser.add_argument_group('required arguments')
-        delete_idp_parser._action_groups.append(optional_delete_idp_parser)
-        required_delete_idp_parser.add_argument("--idp-name",
-            help="IDP name",
-            action="store", dest="idp_name", metavar="",
-            required=True)
-        optional_delete_idp_parser.add_argument("--cluster-name",
-            help="osd cluster name",
-            action="store", dest="cluster_name", metavar="",
-            default="rhoda-qe-test")
-        delete_idp_parser.set_defaults(func=ocm_obj.delete_idp)
+    # Argument parsers for get_osd_cluster_info
+    info_parser = subparsers.add_parser(
+        "get_osd_cluster_info",
+        help=("Gets the cluster information"),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    optional_info_parser = info_parser._action_groups.pop()
+    required_info_parser = info_parser.add_argument_group("required arguments")
+    info_parser._action_groups.append(optional_info_parser)
 
-        #Argument parsers for get_osd_cluster_info
-        info_parser = subparsers.add_parser(
-            'get_osd_cluster_info',
-            help=("Gets the cluster information"),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        optional_info_parser = info_parser._action_groups.pop()
-        required_info_parser = info_parser.add_argument_group('required arguments')
-        info_parser._action_groups.append(optional_info_parser)
+    optional_info_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        metavar="",
+        default="rhoda-qe-test",
+    )
+    optional_info_parser.add_argument(
+        "--config_template",
+        help="template file to generate config",
+        action="store",
+        dest="config_template",
+        metavar="",
+        default="test-variables.yaml.example",
+    )
+    optional_info_parser.add_argument(
+        "--repo_dir",
+        help="template file to generate config",
+        action="store",
+        dest="repo_dir",
+        metavar="",
+        default="",
+    )
+    optional_info_parser.add_argument(
+        "--htpasswd-cluster-password",
+        help="htpasswd Cluster admin password",
+        action="store",
+        dest="htpasswd_cluster_password",
+        metavar="",
+        default="",
+    )
+    info_parser.set_defaults(func=ocm_obj.get_osd_cluster_info)
 
-        optional_info_parser.add_argument("--cluster-name",
-            help="osd cluster name",
-            action="store", dest="cluster_name", metavar="",
-            default="rhoda-qe-test")
-        optional_info_parser.add_argument("--config_template",
-            help="template file to generate config",
-            action="store", dest="config_template", metavar="",
-            default="test-variables.yaml.example")
-        optional_info_parser.add_argument("--repo_dir",
-            help="template file to generate config",
-            action="store", dest="repo_dir", metavar="",
-            default="")
-        optional_info_parser.add_argument("--htpasswd-cluster-password",
-            help="htpasswd Cluster admin password",
-            action="store", dest="htpasswd_cluster_password", metavar="",
-            default="")
-        info_parser.set_defaults(func=ocm_obj.get_osd_cluster_info)
+    # Argument parsers for update_osd_cluster_info
+    update_info_parser = subparsers.add_parser(
+        "update_osd_cluster_info",
+        help=("Updates the cluster information"),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    optional_update_info_parser = update_info_parser._action_groups.pop()
+    required_update_info_parser = update_info_parser.add_argument_group(
+        "required arguments"
+    )
+    update_info_parser._action_groups.append(optional_update_info_parser)
 
-        #Argument parsers for update_osd_cluster_info
-        update_info_parser = subparsers.add_parser(
-            'update_osd_cluster_info',
-            help=("Updates the cluster information"),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        optional_update_info_parser = update_info_parser._action_groups.pop()
-        required_update_info_parser = update_info_parser.add_argument_group('required arguments')
-        update_info_parser._action_groups.append(optional_update_info_parser)
+    optional_update_info_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        metavar="",
+        default="rhoda-qe-test",
+    )
+    optional_update_info_parser.add_argument(
+        "--htpasswd-cluster-password",
+        help="htpasswd Cluster admin password",
+        action="store",
+        dest="htpasswd_cluster_password",
+        metavar="",
+        default="",
+    )
+    optional_update_info_parser.add_argument(
+        "--ldap-test-password",
+        help="Ldap test password",
+        action="store",
+        dest="ldap_test_password",
+        metavar="",
+        default="",
+    )
+    update_info_parser.set_defaults(func=ocm_obj.update_osd_cluster_info)
 
-        optional_update_info_parser.add_argument("--cluster-name",
-            help="osd cluster name",
-            action="store", dest="cluster_name", metavar="",
-            default="rhoda-qe-test")
-        optional_update_info_parser.add_argument("--htpasswd-cluster-password",
-            help="htpasswd Cluster admin password",
-            action="store", dest="htpasswd_cluster_password", metavar="",
-            default="")
-        optional_update_info_parser.add_argument("--ldap-test-password",
-            help="Ldap test password",
-            action="store", dest="ldap_test_password", metavar="",
-            default="")
-        update_info_parser.set_defaults(func=ocm_obj.update_osd_cluster_info)
+    # Argument parsers for install_rhods_addon
+    install_rhods_parser = subparsers.add_parser(
+        "install_rhods_addon",
+        help=("Install rhods addon cluster."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    required_install_rhods_parser = install_rhods_parser.add_argument_group(
+        "required arguments"
+    )
 
-        #Argument parsers for install_rhods_addon
-        install_rhods_parser = subparsers.add_parser(
-            'install_rhods_addon',
-            help=("Install rhods addon cluster."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        required_install_rhods_parser = install_rhods_parser.add_argument_group('required arguments')
+    required_install_rhods_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        required=True,
+    )
+    install_rhods_parser.set_defaults(func=ocm_obj.install_rhods_addon)
 
-        required_install_rhods_parser.add_argument("--cluster-name",
-            help="osd cluster name",
-            action="store", dest="cluster_name",
-            required=True)
-        install_rhods_parser.set_defaults(func=ocm_obj.install_rhods_addon)
+    # Argument parsers for install_rhods_addon
+    install_gpu_parser = subparsers.add_parser(
+        "install_gpu_addon",
+        help=("Install gpu addon cluster."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    required_install_gpu_parser = install_gpu_parser.add_argument_group(
+        "required arguments"
+    )
 
-        #Argument parsers for install_rhods_addon
-        install_gpu_parser = subparsers.add_parser(
-            'install_gpu_addon',
-            help=("Install gpu addon cluster."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        required_install_gpu_parser = install_gpu_parser.add_argument_group('required arguments')
+    required_install_gpu_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        required=True,
+    )
+    install_gpu_parser.set_defaults(func=ocm_obj.install_gpu_addon)
 
-        required_install_gpu_parser.add_argument("--cluster-name",
-            help="osd cluster name",
-            action="store", dest="cluster_name",
-            required=True)
-        install_gpu_parser.set_defaults(func=ocm_obj.install_gpu_addon)
+    # Argument parsers for create_cluster
+    add_machinepool_parser = subparsers.add_parser(
+        "add_machine_pool",
+        help=("Adds machine pool to given cluster via OCM."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-        #Argument parsers for create_cluster
-        add_machinepool_parser = subparsers.add_parser(
-            'add_machine_pool',
-            help=("Adds machine pool to given cluster via OCM."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    optional_machinepool_cluster_parser = add_machinepool_parser._action_groups.pop()
+    required_machinepool_cluster_parser = add_machinepool_parser.add_argument_group(
+        "required arguments"
+    )
+    add_machinepool_parser._action_groups.append(optional_machinepool_cluster_parser)
 
-        optional_machinepool_cluster_parser = add_machinepool_parser._action_groups.pop()
-        required_machinepool_cluster_parser = add_machinepool_parser.add_argument_group('required arguments')
-        add_machinepool_parser._action_groups.append(optional_machinepool_cluster_parser)
+    required_machinepool_cluster_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        required=True,
+    )
 
-        required_machinepool_cluster_parser.add_argument("--cluster-name",
-            help="osd cluster name",
-            action="store", dest="cluster_name",
-            required=True)
+    optional_machinepool_cluster_parser.add_argument(
+        "--instance-type",
+        help="Machine pool instance type",
+        action="store",
+        dest="pool_instance_type",
+        metavar="",
+        default="g4dn.xlarge",
+    )
+    optional_machinepool_cluster_parser.add_argument(
+        "--worker-node-count",
+        help="Machine pool worker node count",
+        action="store",
+        dest="pool_node_count",
+        metavar="",
+        default="1",
+    )
+    optional_machinepool_cluster_parser.add_argument(
+        "--taints",
+        help="Machine pool taints information",
+        action="store",
+        dest="taints",
+        metavar="",
+        default="nvidia.com/gpu=NONE:NoSchedule",
+    )
+    optional_machinepool_cluster_parser.add_argument(
+        "--pool-name",
+        help="Machine pool name",
+        action="store",
+        dest="pool_name",
+        metavar="",
+        default="gpunode",
+    )
+    add_machinepool_parser.set_defaults(func=ocm_obj.add_machine_pool)
 
-        optional_machinepool_cluster_parser.add_argument("--instance-type",
-            help="Machine pool instance type",
-            action="store", dest="pool_instance_type", metavar="",
-            default="g4dn.xlarge")
-        optional_machinepool_cluster_parser.add_argument("--worker-node-count",
-            help="Machine pool worker node count",
-            action="store", dest="pool_node_count", metavar="",
-            default="1")
-        optional_machinepool_cluster_parser.add_argument("--taints",
-            help="Machine pool taints information",
-            action="store", dest="taints", metavar="",
-            default="nvidia.com/gpu=NONE:NoSchedule")
-        optional_machinepool_cluster_parser.add_argument("--pool-name",
-            help="Machine pool name",
-            action="store", dest="pool_name", metavar="",
-            default="gpunode")
-        add_machinepool_parser.set_defaults(func=ocm_obj.add_machine_pool)
+    # Argument parsers for uninstall_rhods_addon
+    uninstall_rhods_parser = subparsers.add_parser(
+        "uninstall_rhods_addon",
+        help=("Uninstall rhods addon cluster."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    required_uninstall_rhods_parser = uninstall_rhods_parser.add_argument_group(
+        "required arguments"
+    )
 
-        #Argument parsers for uninstall_rhods_addon
-        uninstall_rhods_parser = subparsers.add_parser(
-            'uninstall_rhods_addon',
-            help=("Uninstall rhods addon cluster."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        required_uninstall_rhods_parser = uninstall_rhods_parser.add_argument_group('required arguments')
+    required_uninstall_rhods_parser.add_argument(
+        "--cluster-name",
+        help="rhoda cluster name",
+        action="store",
+        dest="cluster_name",
+        required=True,
+    )
+    uninstall_rhods_parser.set_defaults(func=ocm_obj.uninstall_rhods_addon)
 
-        required_uninstall_rhods_parser.add_argument("--cluster-name",
-            help="rhoda cluster name",
-            action="store", dest="cluster_name",
-            required=True)
-        uninstall_rhods_parser.set_defaults(func=ocm_obj.uninstall_rhods_addon)
+    # Argument parsers for install_rhoda_addon
+    install_rhoda_parser = subparsers.add_parser(
+        "install_rhoda_addon",
+        help=("Install rhoda addon cluster."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    required_install_rhoda_parser = install_rhoda_parser.add_argument_group(
+        "required arguments"
+    )
+    required_install_rhoda_parser.add_argument(
+        "--cluster-name",
+        help="osd cluster name",
+        action="store",
+        dest="cluster_name",
+        required=True,
+    )
+    install_rhoda_parser.set_defaults(func=ocm_obj.install_rhoda_addon)
 
-        # Argument parsers for install_rhoda_addon
-        install_rhoda_parser = subparsers.add_parser(
-            'install_rhoda_addon',
-            help=("Install rhoda addon cluster."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        required_install_rhoda_parser = install_rhoda_parser.add_argument_group('required arguments')
-        required_install_rhoda_parser.add_argument("--cluster-name",
-                                                   help="osd cluster name",
-                                                   action="store", dest="cluster_name",
-                                                   required=True)
-        install_rhoda_parser.set_defaults(func=ocm_obj.install_rhoda_addon)
+    # Argument parsers for uninstall_rhoda_addon
+    uninstall_rhoda_parser = subparsers.add_parser(
+        "uninstall_rhoda_addon",
+        help=("Uninstall rhoda addon cluster."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    required_uninstall_rhoda_parser = uninstall_rhoda_parser.add_argument_group(
+        "required arguments"
+    )
+    required_uninstall_rhoda_parser.add_argument(
+        "--cluster-name",
+        help="rhoda cluster name",
+        action="store",
+        dest="cluster_name",
+        required=True,
+    )
+    uninstall_rhoda_parser.set_defaults(func=ocm_obj.uninstall_rhoda_addon)
+    # Argument parsers for create_idp
+    create_idp_parser = subparsers.add_parser(
+        "create_idp",
+        help=("Add an Identity providers to determine how users log into the cluster."),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    optional_create_idp_parser = create_idp_parser._action_groups.pop()
+    required_create_idp_parser = create_idp_parser.add_argument_group(
+        "required arguments"
+    )
+    ldap_create_idp_parser = create_idp_parser.add_argument_group(
+        "  Options for ldap IDP"
+    )
+    htpasswd_create_idp_parser = create_idp_parser.add_argument_group(
+        "  Options for htpasswd IDP"
+    )
+    create_idp_parser._action_groups.append(optional_create_idp_parser)
 
-        # Argument parsers for uninstall_rhoda_addon
-        uninstall_rhoda_parser = subparsers.add_parser(
-            'uninstall_rhoda_addon',
-            help=("Uninstall rhoda addon cluster."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        required_uninstall_rhoda_parser = uninstall_rhoda_parser.add_argument_group('required arguments')
-        required_uninstall_rhoda_parser.add_argument("--cluster-name",
-                                                     help="rhoda cluster name",
-                                                     action="store", dest="cluster_name",
-                                                     required=True)
-        uninstall_rhoda_parser.set_defaults(func=ocm_obj.uninstall_rhoda_addon)
-        #Argument parsers for create_idp
-        create_idp_parser = subparsers.add_parser(
-            'create_idp',
-            help=("Add an Identity providers to determine how users log into the cluster."),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-        optional_create_idp_parser = create_idp_parser._action_groups.pop()
-        required_create_idp_parser = create_idp_parser.add_argument_group('required arguments')
-        ldap_create_idp_parser = create_idp_parser.add_argument_group('  Options for ldap IDP')
-        htpasswd_create_idp_parser = create_idp_parser.add_argument_group('  Options for htpasswd IDP')
-        create_idp_parser._action_groups.append(optional_create_idp_parser)
+    required_create_idp_parser.add_argument(
+        "--type",
+        help="Type of identity provider. Options are [ldap htpasswd]",
+        action="store",
+        dest="idp_type",
+        required=True,
+        choices=["ldap", "htpasswd"],
+    )
+    required_create_idp_parser.add_argument(
+        "--cluster",
+        help="Cluster name",
+        action="store",
+        dest="cluster_name",
+        required=True,
+    )
+    ldap_create_idp_parser.add_argument(
+        "--ldap-url ",
+        help="ldap: Ldap url",
+        metavar=" ",
+        default=(
+            "ldap://openldap.openldap.svc."
+            "cluster.local:1389"
+            "/dc=example,dc=org?uid"
+        ),
+    )
+    ldap_create_idp_parser.add_argument(
+        "--ldap-bind-dn ",
+        help="ldap: Ldap bind dn",
+        metavar=" ",
+        default="cn=admin,dc=example,dc=org",
+    )
+    ldap_create_idp_parser.add_argument(
+        "--num-users-to-create-per-group ",
+        metavar=" ",
+        help="ldap: Number of users to create per group",
+        default="20",
+    )
+    htpasswd_create_idp_parser.add_argument(
+        "--htpasswd-cluster-admin ",
+        help="Cluster admin user of idp type htpasswd",
+        metavar=" ",
+        default="htpasswd-cluster-admin-user",
+    )
+    known_args = parser.parse_known_args()
+    if "idp_type" in known_args[0]:
+        idp_type = known_args[0].idp_type
+        if idp_type == "ldap":
+            optional_create_idp_parser.add_argument(
+                "--ldap-url",
+                help="ldap: Ldap url",
+                action="store",
+                dest="ldap_url",
+                metavar="",
+                default=(
+                    "ldap://openldap.openldap.svc."
+                    "cluster.local:1389"
+                    "/dc=example,dc=org?uid"
+                ),
+            )
+            optional_create_idp_parser.add_argument(
+                "--ldap-bind-dn",
+                help="ldap: Ldap bind dn",
+                metavar="",
+                action="store",
+                dest="ldap_bind_dn",
+                default="cn=admin,dc=example,dc=org",
+            )
+            required_create_idp_parser.add_argument(
+                "--ldap-bind-password",
+                help="ldap: Ldap bind password",
+                action="store",
+                dest="ldap_bind_password",
+                required=True,
+            )
+            optional_create_idp_parser.add_argument(
+                "--num-users-to-create-per-group",
+                help="ldap: Ldap bind password",
+                metavar="",
+                action="store",
+                dest="num_users_to_create_per_group",
+                default="20",
+            )
+        elif idp_type == "htpasswd":
+            optional_create_idp_parser.add_argument(
+                "--idp-name",
+                help="Cluster admin's idp name",
+                action="store",
+                dest="idp_name",
+                metavar="",
+                default="htpasswd-cluster-admin",
+            )
 
-        required_create_idp_parser.add_argument("--type",
-            help = "Type of identity provider. Options are [ldap htpasswd]",
-            action="store", dest="idp_type",
-            required=True, choices=['ldap', 'htpasswd'])
-        required_create_idp_parser.add_argument("--cluster",
-            help = "Cluster name",
-            action="store", dest="cluster_name",
-            required=True)
-        ldap_create_idp_parser.add_argument("--ldap-url ",
-            help="ldap: Ldap url", metavar=" ",
-            default=("ldap://openldap.openldap.svc."
-                     "cluster.local:1389"
-                     "/dc=example,dc=org?uid"))
-        ldap_create_idp_parser.add_argument("--ldap-bind-dn ",
-            help="ldap: Ldap bind dn", metavar=" ",
-            default="cn=admin,dc=example,dc=org")
-        ldap_create_idp_parser.add_argument("--num-users-to-create-per-group ", metavar=" ",
-            help="ldap: Number of users to create per group",
-            default="20")
-        htpasswd_create_idp_parser.add_argument("--htpasswd-cluster-admin ",
-                            help="Cluster admin user of idp type htpasswd", metavar=" ",
-                            default="htpasswd-cluster-admin-user")
-        known_args = parser.parse_known_args()
-        if "idp_type" in known_args[0]:
-            idp_type = known_args[0].idp_type
-            if idp_type == "ldap":
-                optional_create_idp_parser.add_argument("--ldap-url",
-                    help="ldap: Ldap url",
-                    action="store", dest="ldap_url", metavar="",
-                    default=("ldap://openldap.openldap.svc."
-                             "cluster.local:1389"
-                             "/dc=example,dc=org?uid"))
-                optional_create_idp_parser.add_argument("--ldap-bind-dn",
-                    help="ldap: Ldap bind dn", metavar="",
-                    action="store", dest="ldap_bind_dn",
-                    default="cn=admin,dc=example,dc=org")
-                required_create_idp_parser.add_argument("--ldap-bind-password",
-                    help="ldap: Ldap bind password",
-                    action="store", dest="ldap_bind_password", required=True)
-                optional_create_idp_parser.add_argument("--num-users-to-create-per-group",
-                    help="ldap: Ldap bind password", metavar="",
-                    action="store", dest="num_users_to_create_per_group",
-                    default="20")
-            elif idp_type == "htpasswd":
-                optional_create_idp_parser.add_argument("--idp-name",
-                                help="Cluster admin's idp name",
-                                action="store", dest="idp_name", metavar="",
-                                default="htpasswd-cluster-admin")
+            optional_create_idp_parser.add_argument(
+                "--htpasswd-cluster-admin",
+                help="Cluster admin user of idp type htpasswd",
+                action="store",
+                dest="htpasswd_cluster_admin",
+                metavar="",
+                default="htpasswd-cluster-admin-user",
+            )
 
-                optional_create_idp_parser.add_argument("--htpasswd-cluster-admin",
-                                help="Cluster admin user of idp type htpasswd",
-                                action="store", dest="htpasswd_cluster_admin", metavar="",
-                                default="htpasswd-cluster-admin-user")
+            required_create_idp_parser.add_argument(
+                "--htpasswd-cluster-password",
+                help="htpasswd Cluster admin password",
+                action="store",
+                dest="htpasswd_cluster_password",
+                required=True,
+            )
+    create_idp_parser.set_defaults(func=ocm_obj.create_idp)
 
-                required_create_idp_parser.add_argument("--htpasswd-cluster-password",
-                                help="htpasswd Cluster admin password",
-                                action="store", dest="htpasswd_cluster_password", required=True)
-        create_idp_parser.set_defaults(func=ocm_obj.create_idp)
-
-        parser.add_argument("-o", "--ocmclibinaryurl",
-                            help="ocm cli binary url",
-                            action="store", dest="ocm_cli_binary_url",
-                            default=ocm_cli_binary_url)
-        args = parser.parse_args(namespace=ocm_obj)
-        if hasattr(args, 'func'):
-            args.func()
+    parser.add_argument(
+        "-o",
+        "--ocmclibinaryurl",
+        help="ocm cli binary url",
+        action="store",
+        dest="ocm_cli_binary_url",
+        default=ocm_cli_binary_url,
+    )
+    args = parser.parse_args(namespace=ocm_obj)
+    if hasattr(args, "func"):
+        args.func()

--- a/utils/scripts/polarion/createPolarionTestRun.py
+++ b/utils/scripts/polarion/createPolarionTestRun.py
@@ -6,51 +6,90 @@
 import os
 import ssl
 import argparse
+
 ssl._create_default_https_context = ssl._create_unverified_context
+
 
 def parse_args():
     """Parse CLI arguments"""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description='Create Test Plan and Test run in Polarion'
-        )
-    parser.add_argument("-s", "--releasetestplan",
-                        help="polarion release test plan name to create",
-                        action="store", dest="release_testplan_name",
-                        required=True)
-    parser.add_argument("-t", "--testplanname",
-                        help="polarion test plan name to create",
-                        action="store", dest="testplan_name",
-                        required=True)
-    parser.add_argument("-n", "--testrunname",
-                        help="polarion test run name to create",
-                        action="store", dest="testrun_name",
-                        required=True)
-    parser.add_argument("-i", "--projectid",
-                        help="polarion project ID",
-                        action="store", dest="project_id",
-                        default="OpenDataHub")
-    parser.add_argument("-u", "--username",
-                        help="polarion username",
-                        action="store", dest="username",
-                        required=True)
-    parser.add_argument("-p", "--password",
-                        help="polarion password",
-                        action="store", dest="password",
-                        required=True)
-    parser.add_argument("-c", "--certsfilepath",
-                        help="certificate file",
-                        action="store", dest="certs_filepath",
-                        default="/etc/pki/tls/RH-IT-Root-CA.crt")
-    parser.add_argument("-l", "--polarionurl",
-                        help="polarion URL",
-                        action="store", dest="polarion_url",
-                        default="https://polarion.engineering.redhat.com/polarion")
-    parser.add_argument("-r", "--polarionrepo",
-                        help="Polarion repo",
-                        action="store", dest="polarion_repo",
-                        default="https://polarion.engineering.redhat.com/repo")
+        description="Create Test Plan and Test run in Polarion",
+    )
+    parser.add_argument(
+        "-s",
+        "--releasetestplan",
+        help="polarion release test plan name to create",
+        action="store",
+        dest="release_testplan_name",
+        required=True,
+    )
+    parser.add_argument(
+        "-t",
+        "--testplanname",
+        help="polarion test plan name to create",
+        action="store",
+        dest="testplan_name",
+        required=True,
+    )
+    parser.add_argument(
+        "-n",
+        "--testrunname",
+        help="polarion test run name to create",
+        action="store",
+        dest="testrun_name",
+        required=True,
+    )
+    parser.add_argument(
+        "-i",
+        "--projectid",
+        help="polarion project ID",
+        action="store",
+        dest="project_id",
+        default="OpenDataHub",
+    )
+    parser.add_argument(
+        "-u",
+        "--username",
+        help="polarion username",
+        action="store",
+        dest="username",
+        required=True,
+    )
+    parser.add_argument(
+        "-p",
+        "--password",
+        help="polarion password",
+        action="store",
+        dest="password",
+        required=True,
+    )
+    parser.add_argument(
+        "-c",
+        "--certsfilepath",
+        help="certificate file",
+        action="store",
+        dest="certs_filepath",
+        default="/etc/pki/tls/RH-IT-Root-CA.crt",
+    )
+    parser.add_argument(
+        "-l",
+        "--polarionurl",
+        help="polarion URL",
+        action="store",
+        dest="polarion_url",
+        default="https://polarion.engineering.redhat.com/polarion",
+    )
+    parser.add_argument(
+        "-r",
+        "--polarionrepo",
+        help="Polarion repo",
+        action="store",
+        dest="polarion_repo",
+        default="https://polarion.engineering.redhat.com/repo",
+    )
     return parser.parse_args()
+
 
 def set_pylero_environment(env_config):
     """
@@ -59,32 +98,37 @@ def set_pylero_environment(env_config):
     for env_key in env_config.keys():
         os.environ[env_key] = env_config[env_key]
 
+
 def create_testplan(project_id, release_testplan, build_testplan):
     """
     Creates release test plan and build test plan
     """
     from pylero.plan import Plan
 
-    release_testplan_id = release_testplan.replace(".","_")
-    build_testplan_id = build_testplan.replace(".","_")
+    release_testplan_id = release_testplan.replace(".", "_")
+    build_testplan_id = build_testplan.replace(".", "_")
     rst_res = Plan.search("id:{}".format(release_testplan_id))
     if rst_res == []:
-        Plan.create(release_testplan_id, release_testplan,
-                    project_id, None, "release")
+        Plan.create(release_testplan_id, release_testplan, project_id, None, "release")
     else:
-        print ("release test plan {} already exists".format(release_testplan))
+        print("release test plan {} already exists".format(release_testplan))
     plan = Plan(project_id=project_id, plan_id=release_testplan_id)
     if plan.status == "open":
         plan.status = "inprogress"
         plan.update()
- 
+
     btp_res = Plan.search("id:{}".format(build_testplan_id))
     if btp_res == []:
-        res = Plan.create(build_testplan_id, build_testplan,
-                project_id, release_testplan_id, "iteration")
+        res = Plan.create(
+            build_testplan_id,
+            build_testplan,
+            project_id,
+            release_testplan_id,
+            "iteration",
+        )
     else:
         res = True
-        print ("build test plan {} already exists".format(build_testplan))
+        print("build test plan {} already exists".format(build_testplan))
 
     plan = Plan(project_id=project_id, plan_id=build_testplan_id)
     if plan.status == "open":
@@ -93,6 +137,7 @@ def create_testplan(project_id, release_testplan, build_testplan):
 
     return res
 
+
 def create_testrun(project_id, testrun_name, build_testplan):
     """
     Creates test run and adds plannedin version to the
@@ -100,40 +145,42 @@ def create_testrun(project_id, testrun_name, build_testplan):
     """
     from pylero.test_run import TestRun
 
-    build_testplan_id = build_testplan.replace(".","_")
+    build_testplan_id = build_testplan.replace(".", "_")
     try:
         TestRun(project_id=project_id, test_run_id=testrun_name)
-        print ("test run {} already exists".format(testrun_name))
+        print("test run {} already exists".format(testrun_name))
     except:
-        TestRun.create(project_id, testrun_name,
-                       "Build Acceptance type", testrun_name)
+        TestRun.create(project_id, testrun_name, "Build Acceptance type", testrun_name)
     tr = TestRun(project_id=project_id, test_run_id=testrun_name)
     tr.plannedin = build_testplan_id
     tr.update()
+
 
 def main():
     """main function"""
 
     args = parse_args()
-    env_config = { 'POLARION_URL': args.polarion_url,
-                 'POLARION_REPO': args.polarion_repo,
-                 'POLARION_USERNAME': args.username,
-                 'POLARION_PASSWORD': args.password,
-                 'POLARION_PROJECT': args.project_id,
-                 'POLARION_CERT_PATH': args.certs_filepath }
+    env_config = {
+        "POLARION_URL": args.polarion_url,
+        "POLARION_REPO": args.polarion_repo,
+        "POLARION_USERNAME": args.username,
+        "POLARION_PASSWORD": args.password,
+        "POLARION_PROJECT": args.project_id,
+        "POLARION_CERT_PATH": args.certs_filepath,
+    }
 
     # Set pylero environment variables
     set_pylero_environment(env_config)
 
     # Create test plan
-    testplan = create_testplan(args.project_id,
-                               args.release_testplan_name,
-                               args.testplan_name)
+    testplan = create_testplan(
+        args.project_id, args.release_testplan_name, args.testplan_name
+    )
 
     # Create test run
     if testplan:
         create_testrun(args.project_id, args.testrun_name, args.testplan_name)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/utils/scripts/polarion/polarionUpdater.py
+++ b/utils/scripts/polarion/polarionUpdater.py
@@ -8,8 +8,9 @@ import yaml
 import sys
 import uuid
 import subprocess
+
 dir_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(dir_path+"/../")
+sys.path.append(dir_path + "/../")
 
 from util import clone_config_repo, read_yaml
 
@@ -17,42 +18,71 @@ POLARION_URL = "https://polarion.engineering.redhat.com/polarion/import/xunit"
 PYLERO_REPO = "https://github.com/RedHatQE/pylero.git"
 SCRIPT_DIR = dir_path + "/"
 
+
 def parse_args():
     """Parse CLI arguments"""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description='Script to update ods-ci test results in polarion'
-        )
+        description="Script to update ods-ci test results in polarion",
+    )
 
-    parser.add_argument("-r", "--robotResultFile",
-                        help="robot tests results file",
-                        action="store", dest="robot_result_file",
-                        required=True)
-    parser.add_argument("-x", "--xunitXmlFile",
-                        help="xunit xml robot test result file",
-                        action="store", dest="xunit_xml_file",
-                        required=True)
-    parser.add_argument("-m", "--releasePlanName",
-                        help="release plan name. Usually, product release name",
-                        action="store", dest="release_plan_name",
-                        required=True)
-    parser.add_argument("-n", "--testPlanName",
-                        help="test plan name. This will created as child test plan for "
-                             "release plan. Usually, it will be build number",
-                        action="store", dest="test_plan_name",
-                        required=True)
-    parser.add_argument("-t", "--TestrunTitle",
-                        help="polarion testrun title",
-                        action="store", dest="testrun_title",
-                        required=True)
-    parser.add_argument("-u", "--polarionuser",
-                        help="polarion username",
-                        action="store", dest="polarion_username",
-                        required=True)
-    parser.add_argument("-p", "--polarionpassword",
-                        help="polarion password",
-                        action="store", dest="polarion_password",
-                        required=True)
+    parser.add_argument(
+        "-r",
+        "--robotResultFile",
+        help="robot tests results file",
+        action="store",
+        dest="robot_result_file",
+        required=True,
+    )
+    parser.add_argument(
+        "-x",
+        "--xunitXmlFile",
+        help="xunit xml robot test result file",
+        action="store",
+        dest="xunit_xml_file",
+        required=True,
+    )
+    parser.add_argument(
+        "-m",
+        "--releasePlanName",
+        help="release plan name. Usually, product release name",
+        action="store",
+        dest="release_plan_name",
+        required=True,
+    )
+    parser.add_argument(
+        "-n",
+        "--testPlanName",
+        help="test plan name. This will created as child test plan for "
+        "release plan. Usually, it will be build number",
+        action="store",
+        dest="test_plan_name",
+        required=True,
+    )
+    parser.add_argument(
+        "-t",
+        "--TestrunTitle",
+        help="polarion testrun title",
+        action="store",
+        dest="testrun_title",
+        required=True,
+    )
+    parser.add_argument(
+        "-u",
+        "--polarionuser",
+        help="polarion username",
+        action="store",
+        dest="polarion_username",
+        required=True,
+    )
+    parser.add_argument(
+        "-p",
+        "--polarionpassword",
+        help="polarion password",
+        action="store",
+        dest="polarion_password",
+        required=True,
+    )
 
     return parser.parse_args()
 
@@ -61,16 +91,16 @@ def generate_polarion_config(config_template, config_data, testrun_title):
     """
     Generates test config file dynamically by substituting the values in a template file.
     """
-    shutil.copy(config_template, '.')
+    shutil.copy(config_template, ".")
     config_file = os.path.basename(config_template)
-    with open(config_file, 'r') as fh:
+    with open(config_file, "r") as fh:
         data = yaml.safe_load(fh)
 
     data["testrun_info"]["polarion-testrun-title"] = testrun_title
     data["testrun_info"]["polarion-testrun-id"] = testrun_title
 
-    with open(config_file, 'w') as yaml_file:
-        yaml_file.write( yaml.dump(data, default_flow_style=False, sort_keys=False))
+    with open(config_file, "w") as yaml_file:
+        yaml_file.write(yaml.dump(data, default_flow_style=False, sort_keys=False))
 
 
 def main():
@@ -79,9 +109,7 @@ def main():
     args = parse_args()
 
     # Clone pylero repo
-    ret = clone_config_repo(git_repo = PYLERO_REPO,
-                            git_branch = "main",
-                            repo_dir = "pylero")
+    ret = clone_config_repo(git_repo=PYLERO_REPO, git_branch="main", repo_dir="pylero")
     if not ret:
         sys.exit(1)
 
@@ -102,9 +130,13 @@ def main():
 
     # Add property tag to the test report xml file"
     output_report_file = "polarion-report-" + str(uuid.uuid1()) + ".xml"
-    cmd = ("python3 {} -c {} -i {} -x {} -o {}".format(addPropertyScriptName,
-            polarion_config_file, args.robot_result_file,
-            args.xunit_xml_file, output_report_file))
+    cmd = "python3 {} -c {} -i {} -x {} -o {}".format(
+        addPropertyScriptName,
+        polarion_config_file,
+        args.robot_result_file,
+        args.xunit_xml_file,
+        output_report_file,
+    )
 
     ret = subprocess.call(cmd, shell=True)
     if ret:
@@ -112,9 +144,14 @@ def main():
         return False
 
     # Create test plan and test runs in polarion
-    cmd = ("python3 {} -s {} -t {} -n {} -u {} -p {}".format(testRunCreateScriptName,
-           args.release_plan_name, args.test_plan_name, args.testrun_title,
-           args.polarion_username, args.polarion_password))
+    cmd = "python3 {} -s {} -t {} -n {} -u {} -p {}".format(
+        testRunCreateScriptName,
+        args.release_plan_name,
+        args.test_plan_name,
+        args.testrun_title,
+        args.polarion_username,
+        args.polarion_password,
+    )
 
     ret = subprocess.call(cmd, shell=True)
     if ret:
@@ -122,13 +159,14 @@ def main():
         return False
 
     # Update test results in polarion
-    cmd = ("curl -k -X POST -u {}:{} -F file=@{} {}".format(args.polarion_username,
-            args.polarion_password, output_report_file, POLARION_URL))
+    cmd = "curl -k -X POST -u {}:{} -F file=@{} {}".format(
+        args.polarion_username, args.polarion_password, output_report_file, POLARION_URL
+    )
     ret = subprocess.call(cmd, shell=True)
     if ret:
         print("Failed to update test results in polarion")
         return False
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/utils/scripts/terraform/openstack/provision.py
+++ b/utils/scripts/terraform/openstack/provision.py
@@ -13,7 +13,8 @@ from logger import log
 Class for Openstack Terraform Provisioner
 """
 
-class OpenstackTerraformProvisioner():
+
+class OpenstackTerraformProvisioner:
     def __init__(self, args={}):
 
         # Initialize instance variables
@@ -38,34 +39,55 @@ class OpenstackTerraformProvisioner():
 
     def create_instance(self):
         """Created Openstack vm instance"""
-        ocm_download = "https://github.com/openshift-online/ocm-cli/releases/download/{}/ocm-linux-amd64".format(self.ocm_version)
-        tf = Terraform(working_dir=self.working_dir,
-                       variables={'cloud_name': self.cloud_name,
-                                  'vm_name': self.vm_name,
-                                  'vm_user': self.vm_user,
-                                  'vm_private_key': self.vm_private_key,
-                                  'image_name': self.image_name,
-                                  'flavor_name': self.flavor_name,
-                                  'key_pair': self.key_pair,
-                                  'network_name': self.network_name,
-                                  'ocm_bin' : ocm_download})
+        ocm_download = "https://github.com/openshift-online/ocm-cli/releases/download/{}/ocm-linux-amd64".format(
+            self.ocm_version
+        )
+        tf = Terraform(
+            working_dir=self.working_dir,
+            variables={
+                "cloud_name": self.cloud_name,
+                "vm_name": self.vm_name,
+                "vm_user": self.vm_user,
+                "vm_private_key": self.vm_private_key,
+                "image_name": self.image_name,
+                "flavor_name": self.flavor_name,
+                "key_pair": self.key_pair,
+                "network_name": self.network_name,
+                "ocm_bin": ocm_download,
+            },
+        )
         tf.init()
-        ret, out, err = tf.apply(no_color=IsFlagged, input=False, refresh=False, capture_output=True, skip_plan=True)
+        ret, out, err = tf.apply(
+            no_color=IsFlagged,
+            input=False,
+            refresh=False,
+            capture_output=True,
+            skip_plan=True,
+        )
         if ret != 0:
             log.error("Failed to create instance! {}".format(err))
             sys.exit(1)
 
     def delete_instance(self):
         """Deletes Openstack vm instance"""
-        tf = Terraform(working_dir=self.working_dir,
-                       variables={'cloud_name': self.cloud_name,
-                                  'vm_name': self.vm_name,
-                                  'image_name': self.image_name,
-                                  'flavor_name': self.flavor_name,
-                                  'key_pair': self.key_pair,
-                                  'network_name': self.network_name})
+        tf = Terraform(
+            working_dir=self.working_dir,
+            variables={
+                "cloud_name": self.cloud_name,
+                "vm_name": self.vm_name,
+                "image_name": self.image_name,
+                "flavor_name": self.flavor_name,
+                "key_pair": self.key_pair,
+                "network_name": self.network_name,
+            },
+        )
         tf.init()
-        ret, out, err = tf.destroy(capture_output='yes', no_color=IsNotFlagged, force=IsNotFlagged, auto_approve=True)
+        ret, out, err = tf.destroy(
+            capture_output="yes",
+            no_color=IsNotFlagged,
+            force=IsNotFlagged,
+            auto_approve=True,
+        )
         if ret != 0:
             log.error("Failed to delete instance! {}".format(err))
             sys.exit(1)
@@ -73,172 +95,255 @@ class OpenstackTerraformProvisioner():
     def set_config(self):
         """Creates configuration file for using terraform with openstack"""
         replace_vars = {
-                       "CLOUD_NAME": self.cloud_name,
-                       "AUTH_URL": self.auth_url,
-                       "PROJECT_ID": self.project_id,
-                       "PROJECT_NAME": self.project_name,
-                       "USER_DOMAIN_NAME": self.user_domain_name,
-                       "USERNAME": self.username,
-                       "PASSWORD": self.password,
-                       "REGION_NAME": self.region_name,
-                       "INTERFACE": self.interface,
-                       "IDENTITY_API_VERSION": self.identity_api_version,
-                       }
+            "CLOUD_NAME": self.cloud_name,
+            "AUTH_URL": self.auth_url,
+            "PROJECT_ID": self.project_id,
+            "PROJECT_NAME": self.project_name,
+            "USER_DOMAIN_NAME": self.user_domain_name,
+            "USERNAME": self.username,
+            "PASSWORD": self.password,
+            "REGION_NAME": self.region_name,
+            "INTERFACE": self.interface,
+            "IDENTITY_API_VERSION": self.identity_api_version,
+        }
         template_file = "clouds.jinja"
         output_file = "clouds.yaml"
         search_path = os.path.abspath(os.path.dirname(__file__)) + "/templates"
         render_template(search_path, template_file, output_file, replace_vars)
-        dst_dir = os.path.expanduser('~') + "/.config/openstack/"
+        dst_dir = os.path.expanduser("~") + "/.config/openstack/"
         os.makedirs(dst_dir, exist_ok=True)
         shutil.move(output_file, os.path.join(dst_dir, output_file))
 
 
 if __name__ == "__main__":
 
-        #Instance for OpenstackTerraformProvisioner Class
-        prov_obj = OpenstackTerraformProvisioner()
+    # Instance for OpenstackTerraformProvisioner Class
+    prov_obj = OpenstackTerraformProvisioner()
 
-        parser = argparse.ArgumentParser(
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            description='Script to manage instances in Openstack')
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Script to manage instances in Openstack",
+    )
 
-        subparsers = parser.add_subparsers(title='Available sub commands',
-                                           help='sub-command help')
+    subparsers = parser.add_subparsers(
+        title="Available sub commands", help="sub-command help"
+    )
 
-        #Argument parsers for create_instance
-        create_instance_parser = subparsers.add_parser(
-            'create_instance',
-            help=("Creates an instance in OpenStack"),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    # Argument parsers for create_instance
+    create_instance_parser = subparsers.add_parser(
+        "create_instance",
+        help=("Creates an instance in OpenStack"),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-        optional_create_instance_parser = create_instance_parser._action_groups.pop()
-        required_create_instance_parser = create_instance_parser.add_argument_group('required arguments')
-        create_instance_parser._action_groups.append(optional_create_instance_parser)
-        required_create_instance_parser.add_argument("--cloud_name",
-            help="Cloud provider name",
-            action="store", dest="cloud_name",
-            required=True)
-        required_create_instance_parser.add_argument("--vm_name",
-            help="vm name",
-            action="store", dest="vm_name",
-            required=True)
-        required_create_instance_parser.add_argument("--vm_user",
-            help="vm instance username",
-            action="store", dest="vm_user",
-            required=True)
-        required_create_instance_parser.add_argument("--vm_private_key",
-            help="vm instance private key to login with",
-            action="store", dest="vm_private_key",
-            required=True)
-        required_create_instance_parser.add_argument("--key_pair",
-            help="The public key of an OpenSSH key pair to be used for access to created instances",
-            action="store", dest="key_pair",
-            required=True)
-        required_create_instance_parser.add_argument("--network_name",
-            help="Network Name",
-            action="store", dest="network_name",
-            required=True)
-        optional_create_instance_parser.add_argument("--flavor-name",
-            help="Flavour name",
-            action="store", dest="flavor_name", metavar="",
-            default="m1.medium")
-        optional_create_instance_parser.add_argument("--image-name",
-            help="Image name to create an instance",
-            action="store", dest="image_name", metavar="",
-            default="CentOS-Stream-8-x86_64-GenericCloud")
-        optional_create_instance_parser.add_argument("--ocm-version",
-            help="OCM version to be installed",
-            action="store", dest="ocm_version", metavar="",
-            default="v0.1.62")
-        create_instance_parser.set_defaults(func=prov_obj.create_instance)
+    optional_create_instance_parser = create_instance_parser._action_groups.pop()
+    required_create_instance_parser = create_instance_parser.add_argument_group(
+        "required arguments"
+    )
+    create_instance_parser._action_groups.append(optional_create_instance_parser)
+    required_create_instance_parser.add_argument(
+        "--cloud_name",
+        help="Cloud provider name",
+        action="store",
+        dest="cloud_name",
+        required=True,
+    )
+    required_create_instance_parser.add_argument(
+        "--vm_name", help="vm name", action="store", dest="vm_name", required=True
+    )
+    required_create_instance_parser.add_argument(
+        "--vm_user",
+        help="vm instance username",
+        action="store",
+        dest="vm_user",
+        required=True,
+    )
+    required_create_instance_parser.add_argument(
+        "--vm_private_key",
+        help="vm instance private key to login with",
+        action="store",
+        dest="vm_private_key",
+        required=True,
+    )
+    required_create_instance_parser.add_argument(
+        "--key_pair",
+        help="The public key of an OpenSSH key pair to be used for access to created instances",
+        action="store",
+        dest="key_pair",
+        required=True,
+    )
+    required_create_instance_parser.add_argument(
+        "--network_name",
+        help="Network Name",
+        action="store",
+        dest="network_name",
+        required=True,
+    )
+    optional_create_instance_parser.add_argument(
+        "--flavor-name",
+        help="Flavour name",
+        action="store",
+        dest="flavor_name",
+        metavar="",
+        default="m1.medium",
+    )
+    optional_create_instance_parser.add_argument(
+        "--image-name",
+        help="Image name to create an instance",
+        action="store",
+        dest="image_name",
+        metavar="",
+        default="CentOS-Stream-8-x86_64-GenericCloud",
+    )
+    optional_create_instance_parser.add_argument(
+        "--ocm-version",
+        help="OCM version to be installed",
+        action="store",
+        dest="ocm_version",
+        metavar="",
+        default="v0.1.62",
+    )
+    create_instance_parser.set_defaults(func=prov_obj.create_instance)
 
-        #Argument parsers for delete_instance
-        delete_instance_parser = subparsers.add_parser(
-            'delete_instance',
-            help=("Deletes an instance in OpenStack"),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    # Argument parsers for delete_instance
+    delete_instance_parser = subparsers.add_parser(
+        "delete_instance",
+        help=("Deletes an instance in OpenStack"),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-        optional_delete_instance_parser = delete_instance_parser._action_groups.pop()
-        required_delete_instance_parser = delete_instance_parser.add_argument_group('required arguments')
-        delete_instance_parser._action_groups.append(optional_delete_instance_parser)
-        required_delete_instance_parser.add_argument("--cloud_name",
-            help="Cloud provider name",
-            action="store", dest="cloud_name",
-            required=True)
-        required_delete_instance_parser.add_argument("--vm_name",
-            help="vm name",
-            action="store", dest="vm_name",
-            required=True)
-        required_delete_instance_parser.add_argument("--key_pair",
-            help="The public key of an OpenSSH key pair to be used for access to created instances",
-            action="store", dest="key_pair",
-            required=True)
-        required_delete_instance_parser.add_argument("--network_name",
-            help="Network Name",
-            action="store", dest="network_name",
-            required=True)
-        optional_delete_instance_parser.add_argument("--flavor-name",
-            help="Flavour name",
-            action="store", dest="flavor_name", metavar="",
-            default="m1.medium")
-        optional_delete_instance_parser.add_argument("--image-name",
-            help="Image name to create an instance",
-            action="store", dest="image_name", metavar="",
-            default="CentOS-Stream-8-x86_64-GenericCloud")
-        delete_instance_parser.set_defaults(func=prov_obj.delete_instance)
+    optional_delete_instance_parser = delete_instance_parser._action_groups.pop()
+    required_delete_instance_parser = delete_instance_parser.add_argument_group(
+        "required arguments"
+    )
+    delete_instance_parser._action_groups.append(optional_delete_instance_parser)
+    required_delete_instance_parser.add_argument(
+        "--cloud_name",
+        help="Cloud provider name",
+        action="store",
+        dest="cloud_name",
+        required=True,
+    )
+    required_delete_instance_parser.add_argument(
+        "--vm_name", help="vm name", action="store", dest="vm_name", required=True
+    )
+    required_delete_instance_parser.add_argument(
+        "--key_pair",
+        help="The public key of an OpenSSH key pair to be used for access to created instances",
+        action="store",
+        dest="key_pair",
+        required=True,
+    )
+    required_delete_instance_parser.add_argument(
+        "--network_name",
+        help="Network Name",
+        action="store",
+        dest="network_name",
+        required=True,
+    )
+    optional_delete_instance_parser.add_argument(
+        "--flavor-name",
+        help="Flavour name",
+        action="store",
+        dest="flavor_name",
+        metavar="",
+        default="m1.medium",
+    )
+    optional_delete_instance_parser.add_argument(
+        "--image-name",
+        help="Image name to create an instance",
+        action="store",
+        dest="image_name",
+        metavar="",
+        default="CentOS-Stream-8-x86_64-GenericCloud",
+    )
+    delete_instance_parser.set_defaults(func=prov_obj.delete_instance)
 
-        #Argument parsers for set_config
-        set_config_parser = subparsers.add_parser(
-            'set_config',
-            help=("Sets config for using Openstack with terraform"),
-            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    # Argument parsers for set_config
+    set_config_parser = subparsers.add_parser(
+        "set_config",
+        help=("Sets config for using Openstack with terraform"),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-        optional_set_config_parser = set_config_parser._action_groups.pop()
-        required_set_config_parser = set_config_parser.add_argument_group('required arguments')
-        set_config_parser._action_groups.append(optional_set_config_parser)
-        required_set_config_parser.add_argument("--cloud_name",
-            help="Cloud provider name",
-            action="store", dest="cloud_name",
-            required=True)
-        required_set_config_parser.add_argument("--auth_url",
-            help="The identity authentication URL",
-            action="store", dest="auth_url",
-            required=True)
-        required_set_config_parser.add_argument("--username",
-            help="The Username to login with",
-            action="store", dest="username",
-            required=True)
-        required_set_config_parser.add_argument("--password",
-            help="The Password to login with",
-            action="store", dest="password",
-            required=True)
-        required_set_config_parser.add_argument("--project_id",
-            help="The project ID to login with",
-            action="store", dest="project_id",
-            required=True)
-        required_set_config_parser.add_argument("--project_name",
-            help="The project name to login with",
-            action="store", dest="project_name",
-            required=True)
-        required_set_config_parser.add_argument("--user_domain_name",
-            help="The domain name where the user is located",
-            action="store", dest="user_domain_name",
-            required=True)
-        required_set_config_parser.add_argument("--region_name",
-            help="The region of the OpenStack cloud to use",
-            action="store", dest="region_name",
-            required=True)
-        required_set_config_parser.add_argument("--interface",
-            help="Interface Name",
-            action="store", dest="interface",
-            required=True)
-        required_set_config_parser.add_argument("--identity_api_version",
-            help="Identity API verson to use",
-            action="store", dest="identity_api_version",
-            required=True)
+    optional_set_config_parser = set_config_parser._action_groups.pop()
+    required_set_config_parser = set_config_parser.add_argument_group(
+        "required arguments"
+    )
+    set_config_parser._action_groups.append(optional_set_config_parser)
+    required_set_config_parser.add_argument(
+        "--cloud_name",
+        help="Cloud provider name",
+        action="store",
+        dest="cloud_name",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--auth_url",
+        help="The identity authentication URL",
+        action="store",
+        dest="auth_url",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--username",
+        help="The Username to login with",
+        action="store",
+        dest="username",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--password",
+        help="The Password to login with",
+        action="store",
+        dest="password",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--project_id",
+        help="The project ID to login with",
+        action="store",
+        dest="project_id",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--project_name",
+        help="The project name to login with",
+        action="store",
+        dest="project_name",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--user_domain_name",
+        help="The domain name where the user is located",
+        action="store",
+        dest="user_domain_name",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--region_name",
+        help="The region of the OpenStack cloud to use",
+        action="store",
+        dest="region_name",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--interface",
+        help="Interface Name",
+        action="store",
+        dest="interface",
+        required=True,
+    )
+    required_set_config_parser.add_argument(
+        "--identity_api_version",
+        help="Identity API verson to use",
+        action="store",
+        dest="identity_api_version",
+        required=True,
+    )
 
-        set_config_parser.set_defaults(func=prov_obj.set_config)
+    set_config_parser.set_defaults(func=prov_obj.set_config)
 
-        args = parser.parse_args(namespace=prov_obj)
-        if hasattr(args, 'func'):
-            args.func()
+    args = parser.parse_args(namespace=prov_obj)
+    if hasattr(args, "func"):
+        args.func()

--- a/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/utils/scripts/testconfig/generateTestConfigFile.py
@@ -7,52 +7,90 @@ import subprocess
 import shutil
 import yaml
 import sys
+
 dir_path = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(dir_path+"/../")
-from util import (clone_config_repo, read_yaml,
-                  oc_login, execute_command)
+sys.path.append(dir_path + "/../")
+from util import clone_config_repo, read_yaml, oc_login, execute_command
+
 
 def parse_args():
     """Parse CLI arguments"""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        description='Script to generate test config file'
-        )
-    parser.add_argument("-u", "--gituser",
-                        help="git username",
-                        action="store", dest="git_username",
-                        default="")
-    parser.add_argument("-p", "--gitpassword",
-                        help="git password",
-                        action="store", dest="git_password",
-                        default="")
-    parser.add_argument("-r", "--gitrepo",
-                        help="config git repo for ods-ci tests",
-                        action="store", dest="git_repo",
-                        default="https://gitlab.cee.redhat.com/ods/odhcluster.git")
-    parser.add_argument("-b", "--gitRepoBranch",
-                        help="config git repo branch for ods-ci tests",
-                        action="store", dest="git_repo_branch",
-                        default="master")
-    parser.add_argument("-d", "--repoDir",
-                        help="directory to clone the git repo",
-                        action="store", dest="repo_dir",
-                        default="configrepo")
-    parser.add_argument("-c", "--configtemplate",
-                        help="absolute path of test config yaml file template",
-                        action="store", dest="config_template",
-                        default="utils/scripts/testconfig/test-variables.yaml")
-    parser.add_argument("-t", "--testcluster",
-                        help="Test cluster. Eg: modh-qe-1",
-                        action="store", dest="test_cluster",
-                        required=True)
-    parser.add_argument("-o", "--setPromotheusConfig",
-                        help="append prometheus config to config file",
-                        action="store_true", dest="set_prometheus_config")
-    parser.add_argument("-s", "--skip-git-clone",
-                        help="If this option is used then cloning config git repo for ods-ci tests is skipped.",
-                        action="store_true", dest="skip_clone")
+        description="Script to generate test config file",
+    )
+    parser.add_argument(
+        "-u",
+        "--gituser",
+        help="git username",
+        action="store",
+        dest="git_username",
+        default="",
+    )
+    parser.add_argument(
+        "-p",
+        "--gitpassword",
+        help="git password",
+        action="store",
+        dest="git_password",
+        default="",
+    )
+    parser.add_argument(
+        "-r",
+        "--gitrepo",
+        help="config git repo for ods-ci tests",
+        action="store",
+        dest="git_repo",
+        default="https://gitlab.cee.redhat.com/ods/odhcluster.git",
+    )
+    parser.add_argument(
+        "-b",
+        "--gitRepoBranch",
+        help="config git repo branch for ods-ci tests",
+        action="store",
+        dest="git_repo_branch",
+        default="master",
+    )
+    parser.add_argument(
+        "-d",
+        "--repoDir",
+        help="directory to clone the git repo",
+        action="store",
+        dest="repo_dir",
+        default="configrepo",
+    )
+    parser.add_argument(
+        "-c",
+        "--configtemplate",
+        help="absolute path of test config yaml file template",
+        action="store",
+        dest="config_template",
+        default="utils/scripts/testconfig/test-variables.yaml",
+    )
+    parser.add_argument(
+        "-t",
+        "--testcluster",
+        help="Test cluster. Eg: modh-qe-1",
+        action="store",
+        dest="test_cluster",
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        "--setPromotheusConfig",
+        help="append prometheus config to config file",
+        action="store_true",
+        dest="set_prometheus_config",
+    )
+    parser.add_argument(
+        "-s",
+        "--skip-git-clone",
+        help="If this option is used then cloning config git repo for ods-ci tests is skipped.",
+        action="store_true",
+        dest="skip_clone",
+    )
     return parser.parse_args()
+
 
 def get_prometheus_token(project):
     """
@@ -62,44 +100,78 @@ def get_prometheus_token(project):
     prometheus_token = execute_command(cmd)
     return prometheus_token.strip("\n")
 
+
 def get_prometheus_url(project):
     """
     Get prometheus url for the cluster.
     """
     host_jsonpath = "{.spec.host}"
-    cmd = "oc get route prometheus -n {} -o jsonpath='{}'".format(project, host_jsonpath)
+    cmd = "oc get route prometheus -n {} -o jsonpath='{}'".format(
+        project, host_jsonpath
+    )
     prometheus_url = execute_command(cmd)
     return "https://" + prometheus_url.strip("\n")
 
-def generate_test_config_file(config_template, config_data, test_cluster, set_prometheus_config):
+
+def generate_test_config_file(
+    config_template, config_data, test_cluster, set_prometheus_config
+):
     """
     Generates test config file dynamically by substituting the values in a template file.
     """
-    shutil.copy(config_template, '.')
+    shutil.copy(config_template, ".")
     config_file = os.path.basename(config_template)
-    with open(config_file, 'r') as fh:
+    with open(config_file, "r") as fh:
         data = yaml.safe_load(fh)
 
     data["BROWSER"]["NAME"] = config_data["BROWSER"]["NAME"]
     data["S3"]["AWS_ACCESS_KEY_ID"] = config_data["S3"]["AWS_ACCESS_KEY_ID"]
     data["S3"]["AWS_SECRET_ACCESS_KEY"] = config_data["S3"]["AWS_SECRET_ACCESS_KEY"]
     data["ANACONDA_CE"]["ACTIVATION_KEY"] = config_data["ANACONDA_CE"]["ACTIVATION_KEY"]
-    data["OCP_CONSOLE_URL"] = config_data["TEST_CLUSTERS"][test_cluster]["OCP_CONSOLE_URL"]
-    data["ODH_DASHBOARD_URL"] = config_data["TEST_CLUSTERS"][test_cluster]["ODH_DASHBOARD_URL"]
-    data["TEST_USER"]["AUTH_TYPE"] = config_data["TEST_CLUSTERS"][test_cluster]["TEST_USER"]["AUTH_TYPE"]
-    data["TEST_USER"]["USERNAME"] = config_data["TEST_CLUSTERS"][test_cluster]["TEST_USER"]["USERNAME"]
-    data["TEST_USER"]["PASSWORD"] = config_data["TEST_CLUSTERS"][test_cluster]["TEST_USER"]["PASSWORD"]
-    data["OCP_ADMIN_USER"]["AUTH_TYPE"] = config_data["TEST_CLUSTERS"][test_cluster]["OCP_ADMIN_USER"]["AUTH_TYPE"]
-    data["OCP_ADMIN_USER"]["USERNAME"] = config_data["TEST_CLUSTERS"][test_cluster]["OCP_ADMIN_USER"]["USERNAME"]
-    data["OCP_ADMIN_USER"]["PASSWORD"] = config_data["TEST_CLUSTERS"][test_cluster]["OCP_ADMIN_USER"]["PASSWORD"]
+    data["OCP_CONSOLE_URL"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "OCP_CONSOLE_URL"
+    ]
+    data["ODH_DASHBOARD_URL"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "ODH_DASHBOARD_URL"
+    ]
+    data["TEST_USER"]["AUTH_TYPE"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "TEST_USER"
+    ]["AUTH_TYPE"]
+    data["TEST_USER"]["USERNAME"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "TEST_USER"
+    ]["USERNAME"]
+    data["TEST_USER"]["PASSWORD"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "TEST_USER"
+    ]["PASSWORD"]
+    data["OCP_ADMIN_USER"]["AUTH_TYPE"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "OCP_ADMIN_USER"
+    ]["AUTH_TYPE"]
+    data["OCP_ADMIN_USER"]["USERNAME"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "OCP_ADMIN_USER"
+    ]["USERNAME"]
+    data["OCP_ADMIN_USER"]["PASSWORD"] = config_data["TEST_CLUSTERS"][test_cluster][
+        "OCP_ADMIN_USER"
+    ]["PASSWORD"]
     data["SSO"]["USERNAME"] = config_data["SSO"]["USERNAME"]
     data["SSO"]["PASSWORD"] = config_data["SSO"]["PASSWORD"]
-    data["RHOSAK_CONFIG_TEST"]["STREAM_REGION"] = config_data["RHOSAK_CONFIG_TEST"]["STREAM_REGION"]
-    data["RHOSAK_CONFIG_TEST"]["CLOUD_PROVIDER"] = config_data["RHOSAK_CONFIG_TEST"]["CLOUD_PROVIDER"]
-    data["RHOSAK_CONFIG_TEST"]["STREAM_NAME"] = config_data["RHOSAK_CONFIG_TEST"]["STREAM_NAME"]
-    data["RHOSAK_CONFIG_TEST"]["SERVICE_ACCOUNT"] = config_data["RHOSAK_CONFIG_TEST"]["SERVICE_ACCOUNT"]
-    data["RHOSAK_CONFIG_TEST"]["TOPIC_NAME"] = config_data["RHOSAK_CONFIG_TEST"]["TOPIC_NAME"]
-    data["RHOSAK_CONFIG_TEST"]["CONSUMER_GROUP"] = config_data["RHOSAK_CONFIG_TEST"]["CONSUMER_GROUP"]
+    data["RHOSAK_CONFIG_TEST"]["STREAM_REGION"] = config_data["RHOSAK_CONFIG_TEST"][
+        "STREAM_REGION"
+    ]
+    data["RHOSAK_CONFIG_TEST"]["CLOUD_PROVIDER"] = config_data["RHOSAK_CONFIG_TEST"][
+        "CLOUD_PROVIDER"
+    ]
+    data["RHOSAK_CONFIG_TEST"]["STREAM_NAME"] = config_data["RHOSAK_CONFIG_TEST"][
+        "STREAM_NAME"
+    ]
+    data["RHOSAK_CONFIG_TEST"]["SERVICE_ACCOUNT"] = config_data["RHOSAK_CONFIG_TEST"][
+        "SERVICE_ACCOUNT"
+    ]
+    data["RHOSAK_CONFIG_TEST"]["TOPIC_NAME"] = config_data["RHOSAK_CONFIG_TEST"][
+        "TOPIC_NAME"
+    ]
+    data["RHOSAK_CONFIG_TEST"]["CONSUMER_GROUP"] = config_data["RHOSAK_CONFIG_TEST"][
+        "CONSUMER_GROUP"
+    ]
     data["RHODS_BUILD"]["PULL_SECRET"] = config_data["RHODS_BUILD"]["PULL_SECRET"]
     data["RHODS_BUILD"]["SECRET_FILE"] = config_data["RHODS_BUILD"]["SECRET_FILE"]
     data["RHODS_BUILD"]["IMAGE"] = config_data["RHODS_BUILD"]["IMAGE"]
@@ -114,7 +186,11 @@ def generate_test_config_file(config_template, config_data, test_cluster, set_pr
     data["TEST_USER_4"]["PASSWORD"] = config_data["TEST_USER_4"]["PASSWORD"]
 
     # Login to test cluster using oc command
-    oc_login(data["OCP_CONSOLE_URL"], data["OCP_ADMIN_USER"]["USERNAME"], data["OCP_ADMIN_USER"]["PASSWORD"])
+    oc_login(
+        data["OCP_CONSOLE_URL"],
+        data["OCP_ADMIN_USER"]["USERNAME"],
+        data["OCP_ADMIN_USER"]["PASSWORD"],
+    )
 
     if bool(set_prometheus_config):
         # Get prometheus token for test cluster
@@ -125,8 +201,9 @@ def generate_test_config_file(config_template, config_data, test_cluster, set_pr
         prometheus_url = get_prometheus_url("redhat-ods-monitoring")
         data["RHODS_PROMETHEUS_URL"] = prometheus_url
 
-    with open(config_file, 'w') as yaml_file:
-        yaml_file.write( yaml.dump(data, default_flow_style=False, sort_keys=False))
+    with open(config_file, "w") as yaml_file:
+        yaml_file.write(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
 
 def main():
     """main function"""
@@ -134,23 +211,26 @@ def main():
     args = parse_args()
 
     if not args.skip_clone:
-        ret = clone_config_repo(git_repo = args.git_repo,
-                                git_branch = args.git_repo_branch,
-                                repo_dir = args.repo_dir,
-                                git_username = args.git_username,
-                                git_password = args.git_password)
+        ret = clone_config_repo(
+            git_repo=args.git_repo,
+            git_branch=args.git_repo_branch,
+            repo_dir=args.repo_dir,
+            git_username=args.git_username,
+            git_password=args.git_password,
+        )
         if not ret:
             sys.exit(1)
     else:
-        print ("Skipping cloning of config gitlab repo")
+        print("Skipping cloning of config gitlab repo")
 
     config_file = args.repo_dir + "/test-variables.yaml"
     config_data = read_yaml(config_file)
 
     # Generate test config file
-    generate_test_config_file(args.config_template, config_data, args.test_cluster,
-                              args.set_prometheus_config)
+    generate_test_config_file(
+        args.config_template, config_data, args.test_cluster, args.set_prometheus_config
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/utils/scripts/util.py
+++ b/utils/scripts/util.py
@@ -1,4 +1,3 @@
-
 import os
 import subprocess
 import shutil
@@ -8,6 +7,7 @@ import sys
 import time
 import jinja2
 from logger import log
+
 
 def clone_config_repo(**kwargs):
     """
@@ -20,19 +20,23 @@ def clone_config_repo(**kwargs):
         kwargs["git_password"] = ""
 
     try:
-       if os.path.exists(kwargs["repo_dir"]) and os.path.isdir(kwargs["repo_dir"]):
-           shutil.rmtree(kwargs["repo_dir"])
-       os.makedirs(kwargs["repo_dir"])
-       print("git repo dir '%s' created successfully" % kwargs["repo_dir"])
+        if os.path.exists(kwargs["repo_dir"]) and os.path.isdir(kwargs["repo_dir"]):
+            shutil.rmtree(kwargs["repo_dir"])
+        os.makedirs(kwargs["repo_dir"])
+        print("git repo dir '%s' created successfully" % kwargs["repo_dir"])
     except OSError as error:
-       print("git repo dir '%s' can not be created." % kwargs["repo_dir"])
-       return False
+        print("git repo dir '%s' can not be created." % kwargs["repo_dir"])
+        return False
 
     git_repo_with_credens = kwargs["git_repo"]
     if kwargs["git_username"] != "" and kwargs["git_password"] != "":
         git_credens = "{}:{}".format(kwargs["git_username"], kwargs["git_password"])
-        git_repo_with_credens = re.sub(r'(https://)(.*)', r'\1' + git_credens + "@" + r'\2', kwargs["git_repo"])
-    cmd = "git clone {} -b {} {}".format(git_repo_with_credens, kwargs["git_branch"], kwargs["repo_dir"])
+        git_repo_with_credens = re.sub(
+            r"(https://)(.*)", r"\1" + git_credens + "@" + r"\2", kwargs["git_repo"]
+        )
+    cmd = "git clone {} -b {} {}".format(
+        git_repo_with_credens, kwargs["git_branch"], kwargs["repo_dir"]
+    )
     ret = subprocess.call(cmd, shell=True)
     if ret:
         print("Failed to clone repo {}.".format(kwargs["git_repo"]))
@@ -45,7 +49,7 @@ def read_yaml(filename):
     Reads the given config file and returns the contents of file in dict format
     """
     try:
-        with open(filename, 'r') as fh:
+        with open(filename, "r") as fh:
             return yaml.safe_load(fh)
     except OSError as error:
         return None
@@ -56,10 +60,14 @@ def execute_command(cmd, get_stderr=False):
     Executes command in the local node
     """
     try:
-        process = subprocess.run(cmd, shell=True, check=True,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE,
-                                 universal_newlines=True)
+        process = subprocess.run(
+            cmd,
+            shell=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
         output = process.stdout
         if get_stderr:
             err = process.stderr
@@ -77,20 +85,22 @@ def oc_login(ocp_console_url, username, password, timeout=600):
     Login to test cluster using oc cli command
     """
     cluster_api_url = ocp_console_url.replace("console-openshift-console.apps", "api")
-    cluster_api_url = re.sub(r'/$','', cluster_api_url) + ":6443"
-    cmd = "oc login -u {} -p {} {} --insecure-skip-tls-verify=true".format(username, password, cluster_api_url)
+    cluster_api_url = re.sub(r"/$", "", cluster_api_url) + ":6443"
+    cmd = "oc login -u {} -p {} {} --insecure-skip-tls-verify=true".format(
+        username, password, cluster_api_url
+    )
     count = 0
     chk_flag = 0
-    while (count <= timeout):
+    while count <= timeout:
         out = execute_command(cmd)
-        if ((out is not None) and ("Login successful" in out)):
-            print ("Logged into cluster successfully")
+        if (out is not None) and ("Login successful" in out):
+            print("Logged into cluster successfully")
             chk_flag = 1
             break
         time.sleep(5)
         count += 5
     if not chk_flag:
-        print ("Failed to login to cluster")
+        print("Failed to login to cluster")
         sys.exit(1)
 
 
@@ -102,9 +112,10 @@ def render_template(search_path, template_file, output_file, replace_vars):
         templateEnv = jinja2.Environment(loader=templateLoader)
         template = templateEnv.get_template(template_file)
         outputText = template.render(replace_vars)
-        with open(output_file, 'w') as fh:
+        with open(output_file, "w") as fh:
             fh.write(outputText)
     except:
-        print("Failed to render template and create json "
-              "file {}".format(output_file))
+        print(
+            "Failed to render template and create json " "file {}".format(output_file)
+        )
         sys.exit(1)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

With the help of `black`, we have standardized the code visualizes across all our python files. This is the first step in the series of changes to standardize our coding style.

In order to format any python file, we can do the following

```
$ python -m pip install black

# Format a single file
$ black <absolute-path-to-file>.py

# Format all python files
$ black .
```