### PR TITLE
Sorting the import modules using isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88
+

--- a/docs/check-code-style.md
+++ b/docs/check-code-style.md
@@ -75,3 +75,38 @@ Robocop is a tool that performs static code analysis of Robot Framework code.
   robotidy --config /dev/null --transform RenameKeywords  tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot --diff --no-overwrite
   robotidy --config /dev/null --transform RenameKeywords  tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot --diff --overwrite
   ```
+
+# Automatically format python code
+
+There are two tools that is used in this repository to maintain consistent visualization
+of code.
+
+Black is the uncompromising Python code formatter. This allows us to focus on the code
+and avoid contentions with visual indicators.
+
+isort is a utility to sort imports automatically into alphabetical order, section and type.
+
+- Install the required libraries
+  ```black requirement
+  pip install -r requirements-dev.txt
+  ```
+
+- Format a file using the back
+  ```black single file
+  black absolute/path/to/file.py
+  ```
+
+- Format all python files in the repo
+  ```black all files
+  black .
+  ```
+
+- Sort import modules in a python file
+  ```isort file
+  isort absolute/path/to/file.py
+  ```
+
+- Perform sort on all the python files in the repository
+  ```isort all
+  isort .
+  ```

--- a/libs/Helpers.py
+++ b/libs/Helpers.py
@@ -1,5 +1,5 @@
-from semver import VersionInfo
 from robotlibcore import keyword
+from semver import VersionInfo
 
 
 class Helpers:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ robotframework-lsp
 robotframework-robocop
 robotframework-tidy
 black
+isort

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 try:
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 except ImportError:
     from ez_setup import use_setuptools
 
     use_setuptools()
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 
 setup(
     name="rhoda-ci",

--- a/temp/Resources/Page/ODH/JupyterHub/jupyter-helper.py
+++ b/temp/Resources/Page/ODH/JupyterHub/jupyter-helper.py
@@ -1,4 +1,5 @@
 import string
+
 import escapism
 
 

--- a/utils/scripts/ocm/ocm.py
+++ b/utils/scripts/ocm/ocm.py
@@ -1,18 +1,19 @@
-import os
 import argparse
-import re
-import subprocess
-import shutil
-import yaml
-import sys
-import jinja2
-import time
 import glob
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+import jinja2
+import yaml
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(dir_path + "/../")
-from util import clone_config_repo, read_yaml, execute_command
 from logger import log
+from util import clone_config_repo, execute_command, read_yaml
 
 """
 Class for Openshift Cluster Manager

--- a/utils/scripts/polarion/createPolarionTestRun.py
+++ b/utils/scripts/polarion/createPolarionTestRun.py
@@ -3,9 +3,9 @@
 # Install pylero.
 # Doc: https://github.com/RedHatQE/pylero#readme
 
+import argparse
 import os
 import ssl
-import argparse
 
 ssl._create_default_https_context = ssl._create_unverified_context
 

--- a/utils/scripts/polarion/polarionUpdater.py
+++ b/utils/scripts/polarion/polarionUpdater.py
@@ -1,13 +1,14 @@
 # Script to update ods-ci test results in polarion
 
-import os
 import argparse
+import os
 import re
 import shutil
-import yaml
+import subprocess
 import sys
 import uuid
-import subprocess
+
+import yaml
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(dir_path + "/../")

--- a/utils/scripts/polarion/xunit_add_properties.py
+++ b/utils/scripts/polarion/xunit_add_properties.py
@@ -1,10 +1,11 @@
 """Inserts properties from a config file into a xunit format XML file"""
 import argparse
 import codecs
-import xml.etree.ElementTree as et
-from xml.dom import minidom
 import re
+import xml.etree.ElementTree as et
 from copy import deepcopy
+from xml.dom import minidom
+
 import yaml
 
 

--- a/utils/scripts/terraform/openstack/provision.py
+++ b/utils/scripts/terraform/openstack/provision.py
@@ -1,13 +1,14 @@
-import os
 import argparse
-import sys
+import os
 import shutil
+import sys
+
 from python_terraform import *
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(dir_path + "/../../")
-from util import render_template
 from logger import log
+from util import render_template
 
 """
 Class for Openstack Terraform Provisioner

--- a/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/utils/scripts/testconfig/generateTestConfigFile.py
@@ -1,16 +1,17 @@
 # Script to generate test config file
 
-import os
 import argparse
+import os
 import re
-import subprocess
 import shutil
-import yaml
+import subprocess
 import sys
+
+import yaml
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(dir_path + "/../")
-from util import clone_config_repo, read_yaml, oc_login, execute_command
+from util import clone_config_repo, execute_command, oc_login, read_yaml
 
 
 def parse_args():

--- a/utils/scripts/util.py
+++ b/utils/scripts/util.py
@@ -1,11 +1,12 @@
 import os
-import subprocess
-import shutil
-import yaml
 import re
+import shutil
+import subprocess
 import sys
 import time
+
 import jinja2
+import yaml
 from logger import log
 
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

In this PR, all the python files import section is automatically formatted using isort. The utility sorts the packages being imported alphabetically, separated into sections.

There exists a `.isort.cfg` to support compatibility between the linters (isort & black).