### PR TITLE
Defaulted Test Case File to Test Cases Directory

### DIFF
--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -3,7 +3,7 @@ set -eux
 
 # -------- Global Variables --------
 TEST_CASE_LOCATION=tests
-TEST_CASE_FILE=""
+TEST_CASE_FILE=tests
 TEST_VARIABLES_FILE=test-variables.yaml
 TEST_VARIABLES=""
 TEST_ARTIFACT_DIR="test-output"
@@ -85,7 +85,7 @@ disp_usage() {
     echo "      -i <TEST_INCLUDE_TAG>: Specify included tags for Robot"
     echo "      -r <EXTRA_ROBOT_ARGS>: Additional arguments to pass to the robot cli"
     echo "      -s: Skip the installation of required Python Libraries"
-    echo "      -t <TEST_CASE_FILE>: Specify test case to run, should be present under Tests directory"
+    echo "      -t <TEST_CASE_FILE>: Specify test case to run, should be present under tests directory"
     echo "      -u: Update/Create Python VirtualEnv"
     echo "      -v <>: Override/Add global variables specified in the test variables file"
 }


### PR DESCRIPTION
Purpose of this PR is to fix run_robot_test.sh to execute without any CLI inputs.
Test_Case_File variable was assigned a default value _tests_ which is the Test Cases directory. It can be overwritten with _-t_ flag

Signed-off-by: Harsh Kumar <hakumar@redhat.com>