### PR TITLE
CrunchyDB Test Suite and required Keywords added and updated.

### DIFF
--- a/resources/keywords/create_provider_account.resource
+++ b/resources/keywords/create_provider_account.resource
@@ -1,23 +1,28 @@
 *** Settings ***
 Resource    ../keywords/operators.resource
+Resource    ../object_repo/create_dbaasinventory_obj.resource
 Resource    ../object_repo/database_access_obj.resource
 Resource    ../object_repo/installed_operators_obj.resource
 Library     ../../utils/scripts/util.py
 Library     ../../utils/scripts/dbaas_connection.py
 
 
+
 *** Variables ***
 ${provaccname}      ${EMPTY}
+${INV_ORG_ID}       invalid_org_id
+${INV_PUB_KEY}      invalid_pub_key
+${INV_PRI_KEY}      invalid_private_key
 
 *** Keywords ***
-User Filters Project Other Than redhat-dbaas-operator And Navigates To Database Access Page
+User Selects Invalid Namespace For Provider Account Creation And Navigates To Database Access Page
     User Navigates To Installed Operators Under Operators
     User Filters dedicated-admin Namespace On Project Dropdown
     User Navigates To Database Access Page
 
 User Navigates To Create Provider Account Screen From Database Access Page
     ${status}=    Run Keyword And Return Status    Wait Until Page Contains Element    ${tblDBProviderAcc}    timeout=10s
-    Run Keyword If    '${status}' == 'True'
+    Run Keyword If    ${status}
     ...    Select Database Provider Account From Create Button DropDown
     ...    ELSE
     ...    Click Element    ${btnCreateProviderAcc}
@@ -36,21 +41,24 @@ Application Navigate To Create Provider Account Page And Error Message Displayed
     Element Should Be Visible    ${btnCreateDisabled}
     Element Should Be Visible    ${btnCancelEnabled}
 
-User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
+User Filters Project ${PROJECT} On Project DropDown And Navigates To Database Access Page
     User Navigates To Installed Operators Under Operators
-    User Filters redhat-dbaas-operator Namespace On Project Dropdown
+    User Filters ${PROJECT} Namespace On Project Dropdown
     User Navigates To Database Access Page
 
-User Enters Provider Account Name And Selects Database Provider ${dbprovider}
+User Enters Provider Account Name And Selects Database Provider
+    [Arguments]    ${invalid}=${False}
+    ${dbprovider}=    Set Variable    ${isv}
     Wait Until Page Contains Element    ${drpDwnDBProvider}    timeout=20s
-    ${paname}=    Get Provider Account Name    ${dbprovider}
+    ${paname}=    Get Provider Account Name    ${dbprovider}    ${invalid}
     Set Test Variable    ${provaccname}    ${paname}
     Input Text    ${txtBxName}    ${provaccname}
     Select From List By Label    ${drpDwnDBProvider}    ${dbprovider}
 
 User Enters Data To Create MongoDB Provider Account
-    [Arguments]    ${mongoDB}=MongoDB Atlas Cloud Database Service
-    User Enters Provider Account Name And Selects Database Provider ${mongoDB}
+    [Arguments]    ${isv}=MongoDB Atlas Cloud Database Service
+    Set Suite Variable    ${isv}
+    User Enters Provider Account Name And Selects Database Provider
     Wait Until Page Contains Element    ${txtBxMongoDBOrgID}    timeout=10s
     Input Text    ${txtBxMongoDBOrgID}    ${MONGO.ORG_ID}
     Input Text    ${txtBxMongoDBPubAPI}    ${MONGO.PUB_KEY}
@@ -58,33 +66,106 @@ User Enters Data To Create MongoDB Provider Account
     Element Should Be Visible    ${btnCreateEnabled}
     Click Element    ${btnCreateEnabled}
 
-Provider Account Creation Successful And Application Navigates To Success Screen
+User Enters Invalid Data To Create MongoDB Provider Account
+    [Arguments]    ${isv}=MongoDB Atlas Cloud Database Service
+    Set Suite Variable    ${isv}
+    User Enters Provider Account Name And Selects Database Provider    True
+    Wait Until Page Contains Element    ${txtBxMongoDBOrgID}    timeout=10s
+    Input Text    ${txtBxMongoDBOrgID}    ${INV_ORG_ID}
+    Input Text    ${txtBxMongoDBPubAPI}    ${INV_PUB_KEY}
+    Input Text    ${txtBxMongoDBPrivAPI}    ${INV_PRI_KEY}
+    Element Should Be Visible    ${btnCreateEnabled}
+    Click Element    ${btnCreateEnabled}
+
+User Enters Data To Create CrunchyDB Provider Account
+    [Arguments]    ${isv}=Crunchy Bridge managed PostgreSQL
+    Set Suite Variable    ${isv}
+    User Enters Provider Account Name And Selects Database Provider
+    Wait Until Page Contains Element    ${txtBxCrunchyPubAPI}    timeout=10s
+    Input Text    ${txtBxCrunchyPubAPI}    ${CRUNCHY.PUB_KEY}
+    Input Text    ${txtBxCrunchyPrivAPI}    ${CRUNCHY.PRI_KEY}
+    Element Should Be Visible    ${btnCreateEnabled}
+    Click Element    ${btnCreateEnabled}
+
+User Enters Invalid Data To Create CrunchyDB Provider Account
+    [Arguments]    ${isv}=Crunchy Bridge managed PostgreSQL
+    Set Suite Variable    ${isv}
+    User Enters Provider Account Name And Selects Database Provider    True
+    Wait Until Page Contains Element    ${txtBxCrunchyPubAPI}    timeout=10s
+    Input Text    ${txtBxCrunchyPubAPI}    ${INV_PUB_KEY}
+    Input Text    ${txtBxCrunchyPrivAPI}    ${INV_PRI_KEY}
+    Element Should Be Visible    ${btnCreateEnabled}
+    Click Element    ${btnCreateEnabled}
+
+Provider Account Creation Success
     Application Navigates To Provider Account Creation Success Screen
-    Provider Account Creation Success
+    Provider Account Creation Success Page
+    Provider Account Available on Database Access Screen
 
 Application Navigates To Provider Account Creation Success Screen
     Wait Until Keyword Succeeds     5x     2s      Wait Until Page Contains Element    ${lblDBInstSuccess}
     Element Should Be Visible    ${btnViewProviderAcc}
 
-Provider Account Creation Success
+Provider Account Creation Success Page
     Click Element    ${btnViewProviderAcc}
-    Wait Until Page Contains Element    ${btnLastUpdatedHeader}     timeout=10s
+    Wait Until Page Contains Element    ${titleDbaasInventories}    timeout=10s
     Filter ${provaccname} On DBaaS Inventory
     ${elemDbaasInvStatusUpd}=    Replace String    ${elemDbaasInvStatus}    <<paname>>    ${provaccname}
     Wait Until Keyword Succeeds     10x     2s      Wait Until Page Contains Element    ${elemDbaasInvStatusUpd}
     Set Suite Variable    ${provaccname}
 
-User Creates MongoDB Provider Account
+Provider Account Available on Database Access Screen
+    User Navigates To Database Access Under Data Services
+    Wait Until Page Contains Element    ${titleDatabaseAccess}
+    ${elemProvAccUpd}=    Replace String    ${elemProvAcc}    <<paname>>    ${provaccname}
+    ${updProvAcc}=    Replace String    ${elemDBProvider}    <<paname>>    ${provaccname}
+    ${isvName}=    Fetch From Left    ${isv}    ${SPACE}
+    Log To Console    ${isvName}
+    ${elemDBProviderUpd}=    Replace String    ${updProvAcc}    <<isvname>>    ${isvName}
+    Element Should Be Visible    ${elemProvAccUpd}
+    Element Should Be Visible    ${elemDBProviderUpd}
+
+Provider Account Creation Failure
+    Provider Account Creation Failure Screen
+    User Navigates To DBaaS Inventories Screen
+    Check Status Of Invalid Provider Account
+
+Provider Account Creation Failure Screen
+    Wait Until Page Contains Element    ${titleCreateProviderAcc}    timeout=15s
+    Wait Until Page Contains Element     ${lblDBInstFailure}    timeout=20s
+    Page Should Contain Button    ${btnEditProvAcc}
+
+User Navigates To DBaaS Inventories Screen
+    [Arguments]    ${PROJECT}=redhat-dbaas-operator
+    User Navigates To Installed Operators Under Operators
+    User Filters ${PROJECT} Namespace On Project Dropdown
+    Wait Until Page Contains Element    ${elemDbaasStatus}    timeout=15s
+    Page Should Contain Element    ${lnkProvAcc}
+    Click Element    ${lnkProvAcc}
+    Wait Until Page Contains Element    ${titleDbaasInventories}    timeout=10s
+
+Check Status Of Invalid Provider Account
+    Wait Until Page Contains Element    ${titleDbaasInventories}    timeout=10s
+    Filter ${provaccname} On DBaaS Inventory
+    ${elemDbaasInvStatusUpd}=    Replace String    ${elemDbaasInvStatus}    <<paname>>    ${provaccname}
+    Page Should Not Contain Element    ${elemDbaasInvStatusUpd}
+
+User Creates ${databaseProvider} Provider Account
     Run Keyword If    "${provaccname}" == "${EMPTY}"
-    ...    Create MongoDB Provider Account
+    ...    Create ${databaseProvider} Provider Account
     ...  ELSE
     ...    Log To Console    Provider Account ${provaccname} Exists
 
-Create MongoDB Provider Account
+Create ${databaseProvider} Provider Account
     User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
     User Navigates To Create Provider Account Screen From Database Access Page
-    User Enters Data To Create MongoDB Provider Account
-    Provider Account Creation Successful And Application Navigates To Success Screen
+    Run Keyword If    "Mongo" in """${databaseProvider}"""
+    ...    User Enters Data To Create MongoDB Provider Account
+    ...  ELSE IF    "Crunchy" in """${databaseProvider}"""
+    ...    User Enters Data To Create CrunchyDB Provider Account
+    ...  ELSE IF    "Cockroach" in """${databaseProvider}"""
+    ...    User Enters Data To Create CrunchyDB Provider Account
+    Provider Account Creation Success
 
 
 

--- a/resources/keywords/deploy_instance_dev.resource
+++ b/resources/keywords/deploy_instance_dev.resource
@@ -3,15 +3,16 @@ Resource    ../keywords/create_provider_account.resource
 Resource    ../object_repo/developer_catalog_obj.resource
 
 *** Variables ***
-${newProject}      ${EMPTY}
+${newProject}        ${EMPTY}
 ${instanceName}      ${EMPTY}
 
 *** Keywords ***
 User Selects A Project For Database Connection
     Run Keyword If    '${newProject}'=='${EMPTY}'
     ...    Create New Project
-    ...  ELSE
+    ...  ELSE    Run Keywords
     ...    Log To Console    Project ${newProject} exists
+    ...    AND    Set Project Namespace To ${newProject}
 
 Create New Project
     Wait Until Page Contains Element    ${drpDwnProjectSelect}    timeout=15s
@@ -23,7 +24,18 @@ Create New Project
     Set Suite Variable    ${newProject}
     Input Text    ${txtBxProjectName}    ${newProject}
     Click Element    ${btnConfirmCreate}
+    ${lblProjectSelectUpd}=     Replace String    ${lblProjectSelect}    <<project>>    ${newProject}
     Element Should Not Be Visible    ${txtProjectCreateError}
+    Wait Until Page Contains Element    ${lblProjectSelectUpd}
+
+Set Project Namespace To ${proj}
+    Wait Until Page Contains Element    ${drpDwnProjectSelect}    timeout=15s
+    Click Element    ${drpDwnProjectSelect}
+    ${btnProjectSelectUpd}=    Replace String    ${btnProjectSelect}    <<project>>    ${proj}
+    ${lblProjectSelectUpd}=    Replace String    ${lblProjectSelect}    <<project>>    ${proj}
+    Wait Until Page Contains Element    ${btnProjectSelectUpd}    timeout=5s
+    Click Element    ${btnProjectSelectUpd}
+    Element Should Be Visible    ${lblProjectSelectUpd}
 
 User Navigates To Connect ${databaseProvider} Screen On Developers View
     User Selects Developer View
@@ -56,15 +68,17 @@ User Selects Database Instance For The Provider Account
     ${instanceName}=    Select Database Instance    ${tableDevCatDatabaseInstance}    ${btnDevCatDBInstanceConnect}    ${txtAlreadyExists}
     Set Suite Variable    ${instanceName}
 
-User Changes Topology View To List View
+Set ${type} View On Topology View
     Wait Until Page Contains Element    ${btnDevTopologyViewSwitch}     timeout=10s
     ${currentView}=     Get Element Attribute    ${btnDevTopologyViewSwitch}    aria-label
-    Run Keyword If    '${currentView}'=='List view'
-    ...    Click Element    ${currentView}
-    Element Should Be Visible    ${elemGraphView}
+    Run Keyword If    "${type}" in """${currentView}"""
+    ...    Click Element    ${btnDevTopologyViewSwitch}
+    ${btnTopologyViewUpd}=    Replace String    ${btnTopologyView}    <<type>>    ${type}
+    Element Should Not Be Visible    ${btnTopologyViewUpd}
 
 DBSC Instance Deployed On Developer Topology Graph View
     Wait Until Keyword Succeeds     10x     2s      Wait Until Page Contains Element    ${txtBxDisplayOptions}
+    Set Graph View On Topology View
     ${instance}=    Get Substring    ${instanceName}    0   6
     ${elemDBInstanceTopologyUpd}=       Replace String    ${elemDBInstanceTopology}    <<instance>>    ${instance}
     Wait Until Page Contains Element    ${elemDBInstanceTopologyUpd}    timeout=10s
@@ -73,7 +87,7 @@ DBSC Instance Deployed On Developer Topology Graph View
 
 DBSC Instance Deployed On Developer Topology List View
     Wait Until Keyword Succeeds     10x     2s      Wait Until Page Contains Element    ${txtBxDisplayOptions}
-    User Changes Topology View To List View
+    Set List View On Topology View
     ${txtTopologyListInstanceUpd}=       Replace String    ${txtTopologyListInstance}    <<instance>>    ${instanceName}
     Wait Until Page Contains Element    ${txtTopologyListInstanceUpd}  timeout=10s
     Click Element    ${txtTopologyListInstanceUpd}
@@ -82,4 +96,3 @@ DBSC Instance Deployed On Developer Topology List View
 DBSC Instance Pan Displays
     ${elemTopologyInstancePanUpd}=     Replace String    ${elemTopologyInstancePan}    <<instance>>    ${instanceName}
     Wait Until Page Contains Element    ${elemTopologyInstancePanUpd}    timeout=10s
-

--- a/resources/keywords/login.resource
+++ b/resources/keywords/login.resource
@@ -18,6 +18,7 @@ Select Login Authentication Type
     Click Element    link:${auth_type}
 
 Login To Openshift
+    Wait Until Page Contains Element    ${titleLoginPage}    timeout=10s
     Element Should Be Visible    ${titleLoginPage}
     Element Should Be Visible    ${txtBxUserName}
     Element Should Be Visible    ${txtBxPassword}
@@ -37,10 +38,10 @@ User Selects ${perspective} View
     Wait Until Keyword Succeeds    6x    2s    Wait Until Page Contains Element  ${elemPerspectiveOptUpd}
     Click Element    ${elemPerspectiveOptUpd}
 
-Tear Down The Test Suite
-    Log    Test Suite Test Down
-
 User Closes Welcome Message
     ${welcomeTile}=     Run Keyword And Return Status    Element Should Be Visible    ${elemWelcomeTile}
     Run Keyword If    ${welcomeTile}
     ...    Click Element    ${btnWelcomTileClose}
+
+Tear Down The Test Suite
+    Log    Test Suite Test Down

--- a/resources/keywords/navigation.resource
+++ b/resources/keywords/navigation.resource
@@ -1,4 +1,5 @@
 *** Settings ***
+Library     String
 Resource    ../keywords/login.resource
 Resource    ../object_repo/login_obj.resource
 

--- a/resources/object_repo/create_dbaasinventory_obj.resource
+++ b/resources/object_repo/create_dbaasinventory_obj.resource
@@ -1,0 +1,30 @@
+*** Comments ***
+Object Repository for DBaaSInvertories Screen
+
+
+*** Variables ***
+${txtNoDatabaseInstance}        //h2[contains(.,"No Database Instances")]
+${btnCreateProviderAcc}         //button[contains(.,"Create Provider Account")]
+${titleCreateProviderAcc}       //div[@class="section-title" and contains(.,"Create Provider Account")]
+${txtInvalidNamespace}          //h4[contains(.,"Invalid Namespace")]
+${btnCreateDisabled}            //button[contains(.,"Create") and @aria-disabled="true"]
+${btnCancelEnabled}             //button[contains(.,"Cancel") and @aria-disabled="false"]
+${txtBxName}                    id:inventory-name
+${drpDwnDBProvider}             //select[contains(@aria-label,"Database Provider")]
+${txtBxMongoDBOrgID}            id:mongodb-atlas-registration-orgId
+${txtBxMongoDBPubAPI}           id:mongodb-atlas-registration-publicApiKey
+${txtBxMongoDBPrivAPI}          id:mongodb-atlas-registration-privateApiKey
+${txtBxCrunchyPubAPI}           id:crunchy-bridge-registration-publicApiKey
+${txtBxCrunchyPrivAPI}          id:crunchy-bridge-registration-privateApiSecret
+${txtBxCockroachAPI}            id:cockroachdb-cloud-registration-apiSecretKey
+${btnCreateEnabled}             //button[contains(.,"Create") and @aria-disabled="false"]
+${lblDBInstSuccess}             //h2[contains(.,"Database instances") and contains(.,"successful")]
+${btnCancelEnabled}             //button[contains(.,"Cancel")
+${btnViewProviderAcc}           //button[contains(.,"View Provider Accounts")]
+${tblInstanceTable}             id:instance-table
+${btnMenuDropDown}              //button[contains(.,"<<menu>>")]
+${btnMenuOptDropDown}           //a[contains(.,"<<menuopt>>")]
+${tblDBProviderAcc}             id:instance-connection-status-table
+${lblDBInstFailure}             //h2[contains(.,"Database instances") and contains(.,"failed")]
+${txtInvCred}                   //div[contains(.,"Invalid credentials")]
+${btnEditProvAcc}               //button[contains(.,"Edit Provider") and @aria-disabled="false"]

--- a/resources/object_repo/database_access_obj.resource
+++ b/resources/object_repo/database_access_obj.resource
@@ -3,24 +3,6 @@ Object Repository for Database Access Screen
 
 
 *** Variables ***
-${txtNoDatabaseInstance}        //h2[contains(.,"No Database Instances")]
-${btnCreateProviderAcc}         //button[contains(.,"Create Provider Account")]
-${titleCreateProviderAcc}       //div[@class="section-title" and contains(.,"Create Provider Account")]
-${txtInvalidNamespace}          //h4[contains(.,"Invalid Namespace")]
-${btnCreateDisabled}            //button[contains(.,"Create") and @aria-disabled="true"]
-${btnCancelEnabled}             //button[contains(.,"Cancel") and @aria-disabled="false"]
-${txtBxName}                    id:inventory-name
-${drpDwnDBProvider}             //select[contains(@aria-label,"Database Provider")]
-${txtBxMongoDBOrgID}            id:mongodb-atlas-registration-orgId
-${txtBxMongoDBPubAPI}           id:mongodb-atlas-registration-publicApiKey
-${txtBxMongoDBPrivAPI}          id:mongodb-atlas-registration-privateApiKey
-${txtBxCrunchyPubAPI}           id:crunchy-bridge-registration-publicApiKey
-${txtBxCrunchyPrivAPI}          id:crunchy-bridge-registration-privateApiSecret
-${txtBxCockroachAPI}            id:cockroachdb-cloud-registration-apiSecretKey
-${btnCreateEnabled}             //button[contains(.,"Create") and @aria-disabled="false"]
-${lblDBInstSuccess}             //h2[contains(.,"Database instances") and contains(.,"successful")]
-${btnViewProviderAcc}           //button[contains(.,"View Provider Accounts")]
-${tblInstanceTable}             id:instance-table
-${btnMenuDropDown}              //button[contains(.,"<<menu>>")]
-${btnMenuOptDropDown}           //a[contains(.,"<<menuopt>>")]
-${tblDBProviderAcc}             id:instance-connection-status-table
+${titleDatabaseAccess}      //h1[contains(.,"Database Access")]
+${elemProvAcc}              //td[contains(.,"<<paname>>")]
+${elemDBProvider}           //td[contains(.,"<<paname>>")]/parent::tr/td[contains(.,"<<isvname>>")]

--- a/resources/object_repo/developer_catalog_obj.resource
+++ b/resources/object_repo/developer_catalog_obj.resource
@@ -21,7 +21,7 @@ ${btnDevCatDBInstanceConnect}   id:instance-select-button
 ${txtAlreadyExists}             //h4[contains(.,"AlreadyExists")]
 ${elemDBInstanceTopology}       //*[name()="g" and @class="odc-operator-backed-service" and (contains(.,"<<instance>>"))]
 ${btnDevTopologyViewSwitch}     //button[@data-test-id="topology-switcher-view"]
-${elemGraphView}                //button[@data-test-id="topology-switcher-view" and contains(@aria-label,"Graph")]
+${btnTopologyView}              //button[@data-test-id="topology-switcher-view" and contains(@aria-label,"<<type>>")]
 ${elemTopologyInstancePan}      //a[contains(.,"<<instance>>")]
 ${txtTopologyListInstance}      //span[contains(.,"DBaaS")]/parent::div[contains(.,"<<instance>>")]
 ${txtBxDisplayOptions}          //span[contains(.,"Display options")]

--- a/resources/object_repo/installed_operators_obj.resource
+++ b/resources/object_repo/installed_operators_obj.resource
@@ -6,8 +6,9 @@ Object Repository for Installed Operators Screen
 ${elemDbaasStatus}          //a[contains(.,"OpenShift Database Access Operator")]//ancestor::tr/td[contains(.,"Succeeded")]
 ${titleDbaasOperator}       //h1[contains(.,"OpenShift Database Access Operator") and contains(@class,"logo__name")]
 ${elemDbaasInvStatus}       //td[contains(.,"<<paname>>")]/parent::tr/td[contains(.,"SpecSynced, InventoryReady")]
+${titleDbaasInventories}    //h1[contains(.,"DBaaSInventories")]
+${lnkProvAcc}               //a[contains(.,"OpenShift Database Access Operator")]//ancestor::tr//a[contains(.,"Provider Account")]
 ${btnLastUpdatedHeader}     //th[contains(@data-label,"Last updated")]
 ${btnInventoryFilterType}   //button[contains(@data-test-id,"dropdown-button")]
 ${btnInventoryFilterName}   id:NAME-Link
 ${txtBxSearchByName}        //input[@aria-label="Search by name..."]
-

--- a/tests/crunchydb_create_connect.robot
+++ b/tests/crunchydb_create_connect.robot
@@ -2,6 +2,7 @@
 Documentation       To Verify Database Provisioning From Developers view
 Metadata            Version    0.0.1
 
+Library             SeleniumLibrary
 Resource            ../resources/keywords/deploy_instance_dev.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
@@ -11,31 +12,24 @@ Test Teardown       Close Browser
 
 
 *** Test Cases ***
-Scenario: Error Message To Select Valid Namespace For Provider Account Creation
-    [Tags]    smoke    RHOD-45
-    Skip
-    When User Selects Invalid Namespace For Provider Account Creation And Navigates To Database Access Page
-    And User Navigates To Create Provider Account Screen From Database Access Page
-    Then Application Navigate To Create Provider Account Page And Error Message Displayed For Invalid Namespace
-
-Scenario: Verify error message for invalid credentials on MongoDB
-    [Tags]    smoke    RHOD-49-1
+Scenario: Verify error message for invalid credentials on CrunchyDB
+    [Tags]    smoke    RHOD-49-2
     When User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
     And User Navigates To Create Provider Account Screen From Database Access Page
-    And User Enters Invalid Data To Create MongoDB Provider Account
+    And User Enters Invalid Data To Create CrunchyDB Provider Account
     Then Provider Account Creation Failure
 
-Scenario: Create MongoDB Provider Account From Administrator View
-    [Tags]    smoke    RHOD-46
+Scenario: Create CrunchyDB Provider Account From Administrator View
+    [Tags]    smoke    RHOD-47
     When User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
     And User Navigates To Create Provider Account Screen From Database Access Page
-    And User Enters Data To Create MongoDB Provider Account
+    And User Enters Data To Create CrunchyDB Provider Account
     Then Provider Account Creation Success
 
-Scenario: Deploy MongoDB DBSC For MongoDB Provider Account
-    [Tags]    smoke    RHOD-50
+Scenario: Deploy CrunchyDB Database Instance
+    [Tags]    smoke    RHOD-51
     Skip If    "${PREV_TEST_STATUS}" == "FAIL"
-    When User Creates MongoDB Provider Account
-    And User Navigates To Connect MongoDB Atlas Cloud Database Service Screen On Developers View
+    When User Creates CrunchyDB Provider Account
+    And User Navigates To Connect Crunchy Bridge Screen On Developers View
     And User Selects Database Instance For The Provider Account
     Then DBSC Instance Deployed On Developer Topology Graph View

--- a/utils/scripts/util.py
+++ b/utils/scripts/util.py
@@ -131,9 +131,13 @@ def random_string():
     return "".join(random.choice(text) for i in range(5))
 
 
-def get_provider_account_name(string_suffix: string = "DBAAS"):
-    return (random_string() + string_suffix).lower().replace(" ", "-")[:10]
+def get_provider_account_name(string_suffix: string = "DBAAS", invalid=None):
+    isvname = string_suffix.lower().split(" ")[0]
+    if invalid:
+        return str(time.time())[-4:] + "-" + isvname + "-inv"
+    else:
+        return str(time.time())[-4:] + "-" + isvname + "-test"
 
 
 def get_project_name(string_name: list):
-    return ("-".join(string_name) + random_string()).lower().replace(" ", "-")[:25]
+    return str(time.time())[-4:] + "-" + ("-".join(string_name)).lower()


### PR DESCRIPTION
With this PR, the following have been covered - 

- First Test Suite for Crunchy Bridge (currently covers-Creation of Provider Account with valid and invalid credentials, deploying DBaas Instance from the created Provider Account)
- Moves the content of Page Object Resource file _resources/object_repo/database_access_obj.resource_ to _resources/object_repo/create_dbaasinventory.resource_
- Parameterization of Keywords where possible
- Addition of Invalid Credentials Test Case to MongoDB Test Suite

Marks tentative completion of - [DBaaS-521](https://issues.redhat.com/browse/DBAAS-521) and [DBaaS-523](https://issues.redhat.com/browse/DBAAS-523)

Signed-off-by: Harsh Kumar <hakumar@redhat.com>