### PR TITLE
[RHODA]Adding test for creating a provider account for CockroachDB cloud

### DIFF
--- a/resources/keywords/create_provider_account.resource
+++ b/resources/keywords/create_provider_account.resource
@@ -166,7 +166,3 @@ Create ${databaseProvider} Provider Account
     ...  ELSE IF    "Cockroach" in """${databaseProvider}"""
     ...    User Enters Data To Create CrunchyDB Provider Account
     Provider Account Creation Success
-
-
-
-

--- a/resources/keywords/create_provider_account.resource
+++ b/resources/keywords/create_provider_account.resource
@@ -97,6 +97,24 @@ User Enters Invalid Data To Create CrunchyDB Provider Account
     Element Should Be Visible    ${btnCreateEnabled}
     Click Element    ${btnCreateEnabled}
 
+User Enters Data To Create CockroachDB Provider Account
+    [Arguments]    ${isv}=CockroachDB Cloud
+    set Suite Variable    ${isv}
+    User Enters Provider Account Name And Selects Database Provider
+    Wait Until Page Contains Element    ${txtBxCockroachAPI}    timeout=10s
+    Input Text    ${txtBxCockroachAPI}    ${COCKROACH.API_KEY}
+    Element Should Be Visible    ${btnCreateEnabled}
+    Click Element    ${btnCreateEnabled}
+
+User Enters Invalid Data To Create CockroachDB Provider Account
+    [Arguments]    ${isv}=CockroachDB Cloud
+    Set Suite Variable    ${isv}
+    User Enters Provider Account Name And Selects Database Provider    True
+    Wait Until Page Contains Element    ${txtBxCockroachAPI}    timeout=10s
+    Input Text    ${txtBxCockroachAPI}    ${INV_PRI_KEY}
+    Element Should Be Visible    ${btnCreateEnabled}
+    Click Element    ${btnCreateEnabled}
+
 Provider Account Creation Success
     Application Navigates To Provider Account Creation Success Screen
     Provider Account Creation Success Page
@@ -164,5 +182,5 @@ Create ${databaseProvider} Provider Account
     ...  ELSE IF    "Crunchy" in """${databaseProvider}"""
     ...    User Enters Data To Create CrunchyDB Provider Account
     ...  ELSE IF    "Cockroach" in """${databaseProvider}"""
-    ...    User Enters Data To Create CrunchyDB Provider Account
+    ...    User Enters Data To Create CockroachDB Provider Account
     Provider Account Creation Success

--- a/tests/cockroachdb_create_connect.robot
+++ b/tests/cockroachdb_create_connect.robot
@@ -12,16 +12,16 @@ Test Teardown       Close Browser
 
 
 *** Test Cases ***
-Scenario: Error Message To Select Valid Namespace For Provider Account Creation
-    When User Filters Project Other Than redhat-dbaas-operator And Navigates To Database Access Page
+Scenario: Verify error message for invalid credentials on CockroachDB
+    [Tags]    smoke
+    When User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
     And User Navigates To Create Provider Account Screen From Database Access Page
-    Then Application Navigate To Create Provider Account Page And Error Message Displayed For Invalid Namespace
+    And User Enters Invalid Data To Create CockroachDB Provider Account
+    Then Provider Account Creation Failure
 
 Scenario: Create Cockroach Provider Account From Administrator View
+    [Tags]    smoke
     When User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
     And User Navigates To Create Provider Account Screen From Database Access Page
     And User Enters Data To Create CockroachDB Provider Account
-    Then Provider Account Creation Successful And Application Navigates To Success Screen
-
-
-
+    Then Provider Account Creation Success

--- a/tests/create_provider_account_CockroachDB.robot
+++ b/tests/create_provider_account_CockroachDB.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Documentation       To Verify Database Provisioning From Developers view
+Metadata            Version    0.0.1
+
+Library             SeleniumLibrary
+Resource            ../resources/keywords/create_provider_account.resource
+
+Suite Setup         Set Library Search Order    SeleniumLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given The Browser Is On Openshift Home Screen
+Test Teardown       Close Browser
+
+
+*** Test Cases ***
+Scenario: Error Message To Select Valid Namespace For Provider Account Creation
+    When User Filters Project Other Than redhat-dbaas-operator And Navigates To Database Access Page
+    And User Navigates To Create Provider Account Screen From Database Access Page
+    Then Application Navigate To Create Provider Account Page And Error Message Displayed For Invalid Namespace
+
+Scenario: Create Cockroach Provider Account From Administrator View
+    When User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
+    And User Navigates To Create Provider Account Screen From Database Access Page
+    And User Enters Data To Create CockroachDB Provider Account
+    Then Provider Account Creation Successful And Application Navigates To Success Screen
+
+
+


### PR DESCRIPTION
This PR is about creating a new provider account for CockroachDB cloud.
It containes the following changes:
In resource files:
1. resources/keywords/create_provider_account.resource
2. resources/keywords/login.resource
3. resources/object_repo/database_access_obj.resource
And a new test case:
tests/create_provider_account_CockroachDB.robot

Resolves part of Jira ticket: DBAAS-511