### PR TITLE
Provision Crunchy Bridge Database Instance from Admin View. Resolves DBAAS-541

### DIFF
--- a/resources/keywords/create_provider_account.resource
+++ b/resources/keywords/create_provider_account.resource
@@ -9,10 +9,10 @@ Library     ../../utils/scripts/dbaas_connection.py
 
 
 *** Variables ***
-${provaccname}      ${EMPTY}
-${INV_ORG_ID}       invalid_org_id
-${INV_PUB_KEY}      invalid_pub_key
-${INV_PRI_KEY}      invalid_private_key
+${provaccname}        ${EMPTY}
+${INV_ORG_ID}         invalid_org_id
+${INV_PUB_KEY}        invalid_pub_key
+${INV_PRI_KEY}        invalid_private_key
 
 *** Keywords ***
 User Selects Invalid Namespace For Provider Account Creation And Navigates To Database Access Page
@@ -26,6 +26,10 @@ User Navigates To Create Provider Account Screen From Database Access Page
     ...    Select Database Provider Account From Create Button DropDown
     ...    ELSE
     ...    Click Element    ${btnCreateProviderAcc}
+    Sleep    8s
+    Comment    [known issue] Auto Page Refresh - Blind Sleep provided for mitigation
+    ...        Will be replaced with intelligent wait if issue persists in near future
+    ...        Will be removed once issue is fixed
 
 Select ${option} From ${menu} Button DropDown
     ${btnMenuDropDownUpd}=    Replace String    ${btnMenuDropDown}    <<menu>>    ${menu}
@@ -138,7 +142,6 @@ Provider Account Available on Database Access Screen
     ${elemProvAccUpd}=    Replace String    ${elemProvAcc}    <<paname>>    ${provaccname}
     ${updProvAcc}=    Replace String    ${elemDBProvider}    <<paname>>    ${provaccname}
     ${isvName}=    Fetch From Left    ${isv}    ${SPACE}
-    Log To Console    ${isvName}
     ${elemDBProviderUpd}=    Replace String    ${updProvAcc}    <<isvname>>    ${isvName}
     Element Should Be Visible    ${elemProvAccUpd}
     Element Should Be Visible    ${elemDBProviderUpd}
@@ -168,13 +171,24 @@ Check Status Of Invalid Provider Account
     ${elemDbaasInvStatusUpd}=    Replace String    ${elemDbaasInvStatus}    <<paname>>    ${provaccname}
     Page Should Not Contain Element    ${elemDbaasInvStatusUpd}
 
-User Creates ${databaseProvider} Provider Account
-    Run Keyword If    "${provaccname}" == "${EMPTY}"
-    ...    Create ${databaseProvider} Provider Account
-    ...  ELSE
-    ...    Log To Console    Provider Account ${provaccname} Exists
+User Creates Invalid ${databaseProvider} Provider Account
+    User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
+    User Navigates To Create Provider Account Screen From Database Access Page
+    Run Keyword If    "Mongo" in """${databaseProvider}"""
+    ...    User Enters Invalid Data To Create MongoDB Provider Account
+    ...  ELSE IF    "Crunchy" in """${databaseProvider}"""
+    ...    User Enters Invalid Data To Create CrunchyDB Provider Account
+    ...  ELSE IF    "Cockroach" in """${databaseProvider}"""
+    ...    User Enters Invalid Data To Create CockroachDB Provider Account
+    Provider Account Creation Failure
 
-Create ${databaseProvider} Provider Account
+User Creates Valid ${databaseProvider} Provider Account
+    Run Keyword If    "${provaccname}" == "${EMPTY}"
+    ...    Create Valid ${databaseProvider} Provider Account
+    ...  ELSE
+    ...    Log     Provider Account ${provaccname} Exists    console=yes
+
+Create Valid ${databaseProvider} Provider Account
     User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
     User Navigates To Create Provider Account Screen From Database Access Page
     Run Keyword If    "Mongo" in """${databaseProvider}"""

--- a/resources/keywords/deploy_instance_dev.resource
+++ b/resources/keywords/deploy_instance_dev.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource    ../keywords/create_provider_account.resource
 Resource    ../object_repo/developer_catalog_obj.resource
+Resource    ../object_repo/provision_dbinstance_obj.resource
 
 *** Variables ***
 ${newProject}        ${EMPTY}
@@ -63,10 +64,21 @@ User Selects ${databaseProvider} Tile Under Connected Database
     Element Should Be Visible    ${hdrConnectedDBScreen}
 
 User Selects Database Instance For The Provider Account
-    Wait Until Page Contains Element    ${drpDwnDevCatProviderAccount}     timeout=10s
-    Select From List By Label    ${drpDwnDevCatProviderAccount}     ${provaccname}
+    Wait Until Page Contains Element    ${drpDwnDevCatProvAcc}     timeout=10s
+    Select From List By Label    ${drpDwnDevCatProvAcc}     ${provaccname}
     ${instanceName}=    Select Database Instance    ${tableDevCatDatabaseInstance}    ${btnDevCatDBInstanceConnect}    ${txtAlreadyExists}
     Set Suite Variable    ${instanceName}
+
+User Filters And Selects The Created Database Instance
+    Wait Until Page Contains Element    ${drpDwnDevCatProvAcc}     timeout=10s
+    Select From List By Label    ${drpDwnDevCatProvAcc}     ${provaccname}
+    Element Should Be Visible    ${txtBxSearchByName}
+    Input Text    ${txtBxSearchByName}    ${instanceName}
+    ${elemInstanceRadioUpd}=    Replace String    ${elemInstanceRadio}    <<inst-name>>    ${instanceName}
+    Element Should Be Visible    ${elemInstanceRadioUpd}
+    Click Element    ${elemInstanceRadioUpd}
+    Scroll Element Into View    ${btnConnectInst}
+    Click Button    ${btnConnectInst}
 
 Set ${type} View On Topology View
     Wait Until Page Contains Element    ${btnDevTopologyViewSwitch}     timeout=10s
@@ -95,4 +107,4 @@ DBSC Instance Deployed On Developer Topology List View
 
 DBSC Instance Pan Displays
     ${elemTopologyInstancePanUpd}=     Replace String    ${elemTopologyInstancePan}    <<instance>>    ${instanceName}
-    Wait Until Page Contains Element    ${elemTopologyInstancePanUpd}    timeout=10s
+    Wait Until Page Contains Element    ${elemTopologyInstancePanUpd}    timeout=15s

--- a/resources/keywords/navigation.resource
+++ b/resources/keywords/navigation.resource
@@ -10,14 +10,16 @@ User Navigates To ${subMenuOption} Under ${sideNavBarMenu}
     User Selects ${subMenuOption} On ${sideNavBarMenu}
 
 User Expands ${sideNavBarMenu}
-    ${elemNavMenuUpd}=    Replace String    ${elemNavMenu}    <<menu>>    ${sideNavBarMenu}
-    Element Should Be Visible    ${elemNavMenuUpd}
-    Click Element    ${elemNavMenuUpd}
+    ${btnNavMenuUpd}=    Replace String    ${btnNavMenu}    <<menu>>    ${sideNavBarMenu}
+    Element Should Be Visible    ${btnNavMenuUpd}
+    ${expanded}=    Get Element Attribute    ${btnNavMenuUpd}    aria-expanded
+    Run Keyword If    '${expanded}'=='false'
+    ...    Click Element    ${btnNavMenuUpd}
 
 User Selects ${subMenuOption} On ${sideNavBarMenu}
     ${elemNavChildMenuUpd}=    Replace String    ${elemNavChildMenu}    <<menu>>    ${sideNavBarMenu}
     ${elemNavChildMenuUpd}=    Replace String    ${elemNavChildMenuUpd}    <<submenu>>    ${subMenuOption}
-    Element Should Be Visible    ${elemNavChildMenuUpd}
+    Wait Until Element Is Visible    ${elemNavChildMenuUpd}    timeout=3s
     Click Element    ${elemNavChildMenuUpd}
     ${lblChildPageHeader}=    Replace String    ${lblChildPageHeader}    <<submenu>>    ${subMenuOption}
     Wait Until Page Contains Element    ${lblChildPageHeader}    timeout=30s

--- a/resources/keywords/provision_dbinstance.resource
+++ b/resources/keywords/provision_dbinstance.resource
@@ -1,0 +1,74 @@
+*** Settings ***
+Resource    ../keywords/deploy_instance_dev.resource
+Resource    ../object_repo/provision_dbinstance_obj.resource
+Resource    ../object_repo/database_access_obj.resource
+Library     ../../utils/scripts/util.py
+
+
+*** Keywords ***
+User Navigates To Create Database Instance Screen From Database Access Page
+    User Navigates To Database Access Under Data Services
+    Wait Until Page Contains Element    ${titleDatabaseAccess}
+    Select Database Instance From Create Button DropDown
+
+User Selects DBProvider And Provider Account
+    [Arguments]    ${isv_name}=${isv}
+    Wait Until Element Is Visible    ${drpDwnDBProvider}    timeout=20s
+    Wait Until Keyword Succeeds    10s    1s    Toggle Database Provider Drop Down ${isv_name}
+    Wait Until Page Contains Element    ${drpDwnDevCatProvAcc}     timeout=10s
+    Select From List By Label    ${drpDwnDevCatProvAcc}     ${provaccname}
+
+Toggle Database Provider Drop Down ${isv_name}
+    Select From List By Label    ${drpDwnDBProvider}    Select database provider
+    Select From List By Label    ${drpDwnDBProvider}    ${isv_name}
+    Element Should Be Visible    ${drpDwnProvAccOptn}
+
+User Enters Data To Create CrunchyDB Database Instance On Admin View
+    User Selects DBProvider And Provider Account
+    ${instanceName}=    Get Instance Name   adm
+    Set Test Variable    ${instanceName}
+    Input Text    ${txtBxInstName}    ${instanceName}
+    Element Should Be Visible    ${btnCreateEnabled}
+    Click Element    ${btnCreateEnabled}
+
+User Enters Data To Create CrunchyDB Database Instance On Dev
+    [Arguments]    ${isv}=Crunchy Bridge managed PostgreSQL
+    ${instanceName}=    Get Instance Name   dev
+    Set Test Variable    ${instanceName}
+    Input Text    ${txtBxInstName}    ${instanceName}
+    Element Should Be Visible    ${btnCreateEnabled}
+    Click Element    ${btnCreateEnabled}
+    Element Should Be Visible    ${txtCreatingDBInst}
+
+DBSC Instance Provisioned And Deployed On Developer Topology Graph View
+    DBSC Instance Provisioned Successfully
+    DBSC Instance Available On DataBase Access Page
+    DBSC Instance Deployed Successfully
+
+DBSC Instance Provisioned Successfully
+    Wait Until Element Is Visible    ${txtInstCreated}    timeout=25s
+    Element Should Be Visible    ${txtCreationInfo}
+    Element Should Be Visible    ${btnViewInst}
+    Click Button    ${btnViewInst}
+
+DBSC Instance Available On DataBase Access Page
+    Wait Until Page Contains Element    ${titleDatabaseAccess}    timeout=10s
+    Element Should Be Visible    ${txtBxSearchByName}
+    Input Text    ${txtBxSearchByName}    ${instanceName}
+    ${elemInstanceNameUpd}=    Replace String    ${elemInstanceName}    <<inst-name>>    ${instanceName}
+    ${elemInstProvNameUpd}=    Replace String    ${elemInstProvName}    <<inst-name>>    ${instanceName}
+    ${elemInstProvNameUpd}=    Replace String    ${elemInstProvNameUpd}    <<paname>>    ${provaccname}
+    Element Should Be Visible    ${elemInstanceNameUpd}
+    Element Should Be Visible    ${elemInstProvNameUpd}
+
+DBSC Instance Deployed Successfully
+    User Navigates To Connect Crunchy Bridge Screen On Developers View
+    User Filters And Selects The Created Database Instance
+    DBSC Instance Deployed On Developer Topology Graph View
+
+DBSC Instance Retrieval Failed
+    Wait Until Element Is Visible    ${txtInstFailHead}
+    Element Should Be Visible    ${txtInstFailMsg}
+    Element Should Be Visible    ${btnTryAgain}
+    Element Should Be Visible    ${btnClose}
+    Click Button    ${btnClose}

--- a/resources/object_repo/database_access_obj.resource
+++ b/resources/object_repo/database_access_obj.resource
@@ -6,3 +6,5 @@ Object Repository for Database Access Screen
 ${titleDatabaseAccess}      //h1[contains(.,"Database Access")]
 ${elemProvAcc}              //td[contains(.,"<<paname>>")]
 ${elemDBProvider}           //td[contains(.,"<<paname>>")]/parent::tr/td[contains(.,"<<isvname>>")]
+${elemInstanceName}         //td[contains(.,"<<inst-name>>")]
+${elemInstProvName}         //td[contains(.,"<<inst-name>>")]/parent::tr/td[contains(.,"<<paname>>")]

--- a/resources/object_repo/developer_catalog_obj.resource
+++ b/resources/object_repo/developer_catalog_obj.resource
@@ -15,7 +15,7 @@ ${lnkDBProviderTile}            //div[contains(.,"<<dbprovider>>")]/parent::a[co
 ${hdrDBProviderModal}           //h1[contains(.,"Mongo") and contains(@class,"title")]
 ${btnDBProviderConnect}         //div[contains(@class,"overlay-action")]//a[contains(.,"Connect")]
 ${hdrDBProviderConnectScreen}   //h1[contains(.,"Connect") and contains (.,"<<dbprovider>>")]
-${drpDwnDevCatProviderAccount}  //select[contains(@aria-label,"Provider Account")]
+${drpDwnDevCatProvAcc}          //select[contains(@aria-label,"Provider Account")]
 ${tableDevCatDatabaseInstance}  //table[contains(@aria-label,"Instance Table")]//tbody/tr
 ${btnDevCatDBInstanceConnect}   id:instance-select-button
 ${txtAlreadyExists}             //h4[contains(.,"AlreadyExists")]

--- a/resources/object_repo/installed_operators_obj.resource
+++ b/resources/object_repo/installed_operators_obj.resource
@@ -11,4 +11,4 @@ ${lnkProvAcc}               //a[contains(.,"OpenShift Database Access Operator")
 ${btnLastUpdatedHeader}     //th[contains(@data-label,"Last updated")]
 ${btnInventoryFilterType}   //button[contains(@data-test-id,"dropdown-button")]
 ${btnInventoryFilterName}   id:NAME-Link
-${txtBxSearchByName}        //input[@aria-label="Search by name..."]
+${txtBxSearchByName}        //input[contains(@aria-label,"Search by name")]

--- a/resources/object_repo/login_obj.resource
+++ b/resources/object_repo/login_obj.resource
@@ -12,6 +12,7 @@ ${lblLoginError}            //div[contains(@class,"error-placeholder")]/p[contai
 ${titleOverview}            //span[contains(.,"Overview")]
 ${elemNavSideBar}           //div[@id="page-sidebar"]
 ${elemNavMenu}              //li[starts-with(.,"<<menu>>") and contains(@class,"nav")]
+${btnNavMenu}               //li[starts-with(.,"<<menu>>") and contains(@class,"nav")]/button
 ${elemNavChildMenu}         //li[starts-with(.,"<<menu>>") and contains(@class,"nav")]/section//li[contains(.,"<<submenu>>")]
 ${lblChildPageHeader}       //h1[contains(.,"<<submenu>>")]
 ${lblPageTitle}             //span[contains(@data-test-id,"resource-title") and contains(.,"<<header>>")]

--- a/resources/object_repo/provision_dbinstance_obj.resource
+++ b/resources/object_repo/provision_dbinstance_obj.resource
@@ -1,0 +1,17 @@
+*** Comments ***
+Object Repository for Create Database Instance Screen
+
+
+*** Variables ***
+${txtBxInstName}                 //input[@id='instance-name']
+${elemInstanceRadio}             //td[contains(.,"<<inst-name>>")]/parent::tr//input[@aria-label="Select row 0"]
+${btnConnectInst}                //button[@id='instance-select-button']
+${txtCreatingDBInst}             //h3[contains(.,"Creating Database Instance...")]
+${txtInstCreated}                //h2[contains(.,"Database instance creation started")]
+${txtCreationInfo}               //div[contains(.,"The database instance is being created")]
+${btnViewInst}                   //button[contains(.,"View Instances") and @aria-disabled="false"]
+${txtInstFailHead}               //h2[contains(.,"Provider account information retrieval failed")]
+${txtInstFailMsg}                //div[contains(.,"Please try again")]
+${btnTryAgain}                   //button[contains(.,"Try Again") and @aria-disabled="false"]
+${btnClose}                      //button[contains(.,"Close") and @aria-disabled="false"]
+${drpDwnProvAccOptn}             //select[contains(@aria-label,"Provider Account")]/option

--- a/tests/cockroachdb_create_connect.robot
+++ b/tests/cockroachdb_create_connect.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       To Verify Database Provisioning From Developers view
+Documentation       To Verify Provisioning of CockroachDB Provider Account and deployment of Database Instance
 Metadata            Version    0.0.1
 
 Library             SeleniumLibrary

--- a/tests/crunchydb_admin_provision.robot
+++ b/tests/crunchydb_admin_provision.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Documentation       To Verify Database Instance Provisioning From Administrator View
+Metadata            Version    0.0.1
+
+Library             SeleniumLibrary
+Resource            ../resources/keywords/provision_dbinstance.resource
+
+Suite Setup         Set Library Search Order    SeleniumLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given The Browser Is On Openshift Home Screen
+Test Teardown       Close Browser
+
+
+*** Test Cases ***
+Scenario: Provision CrunchyDB Database Instance for Invalid Provider Account
+    [Tags]    smoke    RHOD-57-1
+    When User Creates Invalid CrunchyDB Provider Account
+    And User Navigates To Create Database Instance Screen From Database Access Page
+    And User Selects DBProvider And Provider Account
+    Then DBSC Instance Retrieval Failed
+
+Scenario: Provision CrunchyDB Database Instance from Administrator View
+    [Tags]    smoke    RHOD-57
+    When User Creates Valid CrunchyDB Provider Account
+    And User Navigates To Create Database Instance Screen From Database Access Page
+    And User Enters Data To Create CrunchyDB Database Instance On Admin View
+    Then DBSC Instance Provisioned And Deployed On Developer Topology Graph View

--- a/tests/crunchydb_create_connect.robot
+++ b/tests/crunchydb_create_connect.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       To Verify Database Provisioning From Developers view
+Documentation       To Verify Provisioning of CrunchyDB Provider Account and deployment of Database Instance
 Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
@@ -29,7 +29,8 @@ Scenario: Create CrunchyDB Provider Account From Administrator View
 Scenario: Deploy CrunchyDB Database Instance
     [Tags]    smoke    RHOD-51
     Skip If    "${PREV_TEST_STATUS}" == "FAIL"
-    When User Creates CrunchyDB Provider Account
+    When User Creates Valid CrunchyDB Provider Account
     And User Navigates To Connect Crunchy Bridge Screen On Developers View
     And User Selects Database Instance For The Provider Account
     Then DBSC Instance Deployed On Developer Topology Graph View
+

--- a/tests/installation.robot
+++ b/tests/installation.robot
@@ -3,8 +3,7 @@ Documentation       Test to verify installed operators screen for RHODA
 Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
-Resource            ../resources/keywords/navigation.resource
-Resource            ../resources/keywords/operators.resource
+Resource            ../resources/keywords/create_provider_account.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite
@@ -24,3 +23,9 @@ Scenario: Redhat Dbaas Operator Namespace Created For RHODA Installation
     When User Navigates To Installed Operators Under Operators
     And User Filters redhat-dbaas-operator Namespace On Project Dropdown
     Then Openshift Database Access Operator Filtered With Succeeded Status
+
+Scenario: Error Message To Select Valid Namespace For Provider Account Creation
+    [Tags]    smoke    RHOD-45
+    When User Selects Invalid Namespace For Provider Account Creation And Navigates To Database Access Page
+    And User Navigates To Create Provider Account Screen From Database Access Page
+    Then Application Navigate To Create Provider Account Page And Error Message Displayed For Invalid Namespace

--- a/tests/mongodb_create_connect.robot
+++ b/tests/mongodb_create_connect.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       To Verify Database Provisioning From Developers view
+Documentation       To Verify Provisioning of MongoDB Provider Account and deployment of Database Instance
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/deploy_instance_dev.resource
@@ -11,13 +11,6 @@ Test Teardown       Close Browser
 
 
 *** Test Cases ***
-Scenario: Error Message To Select Valid Namespace For Provider Account Creation
-    [Tags]    smoke    RHOD-45
-    Skip
-    When User Selects Invalid Namespace For Provider Account Creation And Navigates To Database Access Page
-    And User Navigates To Create Provider Account Screen From Database Access Page
-    Then Application Navigate To Create Provider Account Page And Error Message Displayed For Invalid Namespace
-
 Scenario: Verify error message for invalid credentials on MongoDB
     [Tags]    smoke    RHOD-49-1
     When User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
@@ -35,7 +28,7 @@ Scenario: Create MongoDB Provider Account From Administrator View
 Scenario: Deploy MongoDB DBSC For MongoDB Provider Account
     [Tags]    smoke    RHOD-50
     Skip If    "${PREV_TEST_STATUS}" == "FAIL"
-    When User Creates MongoDB Provider Account
+    When User Creates Valid MongoDB Provider Account
     And User Navigates To Connect MongoDB Atlas Cloud Database Service Screen On Developers View
     And User Selects Database Instance For The Provider Account
     Then DBSC Instance Deployed On Developer Topology Graph View

--- a/utils/scripts/util.py
+++ b/utils/scripts/util.py
@@ -141,3 +141,7 @@ def get_provider_account_name(string_suffix: string = "DBAAS", invalid=None):
 
 def get_project_name(string_name: list):
     return str(time.time())[-4:] + "-" + ("-".join(string_name)).lower()
+
+
+def get_instance_name(view: string):
+    return view.lower() + "-inst-" + str(time.time())[-4:]


### PR DESCRIPTION
With this PR, the following changes were implemented - 
- 2 Test cases were added to existing CrunchyDB Test Suite to cover Provisioning of Database Instance from Admin view for Valid and Invalid Provider Accounts
- Required Object Repository(_resources/object_repo/create_dbinstance_obj.resource_) and Keyword Resource file(_resources/keywords/create_instance.resource_) were added for the above task
- Logging method was changed to Log Info on both stdout and Log file
- Expansion of SideBar Menu was optimized

Marks tentative completion of subtask [DbaaS-451](https://issues.redhat.com/browse/DBAAS-541) under [DbaaS-514](https://issues.redhat.com/browse/DBAAS-514)

Signed-off-by: Harsh Kumar <hakumar@redhat.com>