### PR TITLE
Tests to verify provider account import success and failure using CLI

### DIFF
--- a/resources/keywords/import_provider_account.resource
+++ b/resources/keywords/import_provider_account.resource
@@ -12,6 +12,7 @@ ${provaccname}        ${EMPTY}
 ${INV_ORG_ID}         invalid_org_id
 ${INV_PUB_KEY}        invalid_pub_key
 ${INV_PRI_KEY}        invalid_private_key
+${VALID_SECRET}       True
 
 *** Keywords ***
 User Selects Invalid Namespace To Import Database Provider Account And Navigates To Database Access Page
@@ -209,7 +210,7 @@ Import ${databaseProvider} Provider Account
     Provider Account Import Success
 
 User Creates ${isv} Secret Credentials
-    Create Secret CLI    ${isv}
+    Create Secret CLI    ${isv}    ${VALID_SECRET}
     ${cmd}    Set Variable    oc describe Secret/${SECRET_NAME}
     ${stdout} =    Execute Command    ${cmd}    True
     ${stdout_str} =    Convert To String    ${stdout}
@@ -223,8 +224,15 @@ Provider Account Imported Successfully Using CLI
     Wait Until Keyword Succeeds    4x    5s    Describe Provider Account Using OC CLI
 
 Describe Provider Account Using OC CLI
+    [Arguments]     ${status}=True
     ${cmd}    Set Variable    oc describe DbaaSInventory/${provaccname}
     ${stdout} =    Execute Command    ${cmd}    True
     ${stdout_str} =    Convert To String    ${stdout}
-    Should Contain X Times    ${stdout_str}    True 	2    ignore_case=True    strip_spaces=True
+    Should Contain X Times    ${stdout_str}    ${status} 	2    ignore_case=True    strip_spaces=True
 
+User Creates ${isv} Secret With Invalid Credentials
+    Set Test Variable   ${VALID_SECRET}     False
+    User Creates ${isv} Secret Credentials
+
+Provider Account Import Failure Using CLI
+    Wait Until Keyword Succeeds    4x    5s    Describe Provider Account Using OC CLI    False

--- a/tests/cockroachdb_import_connect_cli.robot
+++ b/tests/cockroachdb_import_connect_cli.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Documentation       To Verify Provisioning of CockroachDB Provider Account and deployment of Database Instance Using OC CLI
+Metadata            Version    0.0.1
+
+Resource            ../resources/keywords/deploy_application.resource
+
+Suite Setup         Set Library Search Order    OpenShiftLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given Login To OpenShift CLI
+Test Teardown       Logout Of OpenShift CLI
+
+
+*** Test Cases ***
+Scenario: Import CockroachDB Provider Account Using OC CLI
+    [Tags]    smoke    RHOD-462    cli
+    When User Creates CockroachDB Secret Credentials
+    And User Imports CockroachDB Provider Account Using CLI
+    Then Provider Account Imported Successfully Using CLI
+
+Scenario: Verify Error Message For Invalid Credentials On CockroachDB Using OC CLI
+    [Tags]    smoke    RHOD-472    cli
+    When User Creates CockroachDB Secret With Invalid Credentials
+    And User Imports CockroachDB Provider Account Using CLI
+    Then Provider Account Import Failure Using CLI
+

--- a/tests/crunchydb_import_connect_cli.robot
+++ b/tests/crunchydb_import_connect_cli.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Documentation       To Verify Provisioning of CrunchyDB Provider Account and deployment of Database Instance Using OC CLI
+Metadata            Version    0.0.1
+
+Resource            ../resources/keywords/deploy_application.resource
+
+Suite Setup         Set Library Search Order    OpenShiftLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given Login To OpenShift CLI
+Test Teardown       Logout Of OpenShift CLI
+
+
+*** Test Cases ***
+Scenario: Import CrunchyDB Provider Account Using OC CLI
+    [Tags]    smoke    RHOD-461    cli
+    When User Creates CrunchyDB Secret Credentials
+    And User Imports CrunchyDB Provider Account Using CLI
+    Then Provider Account Imported Successfully Using CLI
+
+Scenario: Verify Error Message For Invalid Credentials On CrunchyDB Using OC CLI
+    [Tags]    smoke    RHOD-471    cli
+    When User Creates CrunchyDB Secret With Invalid Credentials
+    And User Imports CrunchyDB Provider Account Using CLI
+    Then Provider Account Import Failure Using CLI
+

--- a/tests/mongodb_import_connect_cli.robot
+++ b/tests/mongodb_import_connect_cli.robot
@@ -17,3 +17,8 @@ Scenario: Import MongoDB Provider Account Using OC CLI
     And User Imports MongoDB Provider Account Using CLI
     Then Provider Account Imported Successfully Using CLI
 
+Scenario: Verify Error Message For Invalid Credentials On MongoDB Using OC CLI
+    [Tags]    smoke    RHOD-470    cli
+    When User Creates MongoDB Secret With Invalid Credentials
+    And User Imports MongoDB Provider Account Using CLI
+    Then Provider Account Import Failure Using CLI


### PR DESCRIPTION
Signed-off-by: Rajan Ravi <rravi@redhat.com>

Added scripts to verify Import provider account from OC CLI. Scripts added to,

- Verify Import provider account successful with valid credentials for Crunchy and CockroachDB ISV
- Verify Import provider account failure with invalid credentials for Mongo, Crunchy and CockroachDB ISV.

This PR resolves [DBAAS-682](https://issues.redhat.com/browse/DBAAS-682), [DBAAS-683](https://issues.redhat.com/browse/DBAAS-683), [DBAAS-680](https://issues.redhat.com/browse/DBAAS-680), [DBAAS-679](https://issues.redhat.com/browse/DBAAS-679) and [DBAAS-678](https://issues.redhat.com/browse/DBAAS-678)

[result.zip](https://github.com/RHODA-lab/rhoda-ci/files/9009406/rhoda-666-2022-06-29-0837.zip)