### PR TITLE
[RHODA][UI]Adding test for adding duplicate provider account name

### DIFF
--- a/resources/keywords/import_provider_account.resource
+++ b/resources/keywords/import_provider_account.resource
@@ -61,6 +61,12 @@ User Enters Provider Account Name And Selects Database Provider
     Input Text    ${txtBxName}    ${provaccname}
     Select From List By Label    ${drpDwnDBProvider}    ${dbprovider}
 
+User Enters An Existing Provider Account Name And Selects Database Provider
+    ${dbprovider}=    Set Variable    ${isv}
+    Wait Until Keyword Succeeds     5x     2s      Wait Until Page Contains Element    ${drpDwnDBProvider}
+    Input Text    ${txtBxName}    ${provaccname}
+    Select From List By Label    ${drpDwnDBProvider}    ${dbprovider}
+
 User Enters Data To Import MongoDB Provider Account
     [Arguments]    ${isv}=MongoDB Atlas Cloud Database Service
     Set Suite Variable    ${isv}
@@ -107,6 +113,15 @@ User Enters Data To Import CockroachDB Provider Account
     [Arguments]    ${isv}=CockroachDB Cloud
     set Suite Variable    ${isv}
     User Enters Provider Account Name And Selects Database Provider
+    Wait Until Page Contains Element    ${txtBxCockroachAPI}    timeout=10s
+    Input Text    ${txtBxCockroachAPI}    ${COCKROACH.apiSecretKey}
+    Element Should Be Visible    ${btnImportEnabled}
+    Click Element    ${btnImportEnabled}
+
+User Enters Data To Import Duplicate CockroachDB Provider Account
+    [Arguments]    ${isv}=CockroachDB Cloud
+    set Suite Variable    ${isv}
+    User Enters An Existing Provider Account Name And Selects Database Provider
     Wait Until Page Contains Element    ${txtBxCockroachAPI}    timeout=10s
     Input Text    ${txtBxCockroachAPI}    ${COCKROACH.apiSecretKey}
     Element Should Be Visible    ${btnImportEnabled}
@@ -227,4 +242,7 @@ Describe Provider Account Using OC CLI
     ${stdout} =    Execute Command    ${cmd}    True
     ${stdout_str} =    Convert To String    ${stdout}
     Should Contain X Times    ${stdout_str}    True 	2    ignore_case=True    strip_spaces=True
+
+An Error Message Appears For An Existing Provider Account Name
+    Element Should Be Visible    ${lblDuplProvAccName}
 

--- a/resources/object_repo/import_dbaasinventory_obj.resource
+++ b/resources/object_repo/import_dbaasinventory_obj.resource
@@ -30,3 +30,4 @@ ${btnEditProvAcc}               //button[(.="Edit Provider Account") and @aria-d
 ${txtProvNoDBInst}              //div[contains(.,"The Provider Account resource has been created but the database instances could not be fetched.")]
 ${txtErrNoDBInst}               //div[.="No database instance in this Provider Account"]
 ${btnClose}                     //button[contains(.,"Close") and @aria-disabled="false"]
+${lblDuplProvAccName}           //div[@aria-label="Danger Alert"]/div[contains(.,"already exists")]

--- a/tests/generic_tests.robot
+++ b/tests/generic_tests.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation       Test suite used with generic test cases
+Metadata            Version    0.0.1
+
+Library             SeleniumLibrary
+Resource            ../resources/keywords/deploy_application.resource
+
+Suite Setup         Set Library Search Order    SeleniumLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given The Browser Is On Openshift Home Screen
+Test Teardown       Close Browser
+
+
+*** Test Cases ***
+Scenario: Verify error message for duplicate provider account friendly name
+    [Tags]    smoke   RHOD-84-1
+    When User Imports Valid CockroachDB Provider Account
+    And User Navigates To Import Database Provider Account Screen From Database Access Page
+    And User Enters Data To Import Duplicate CockroachDB Provider Account
+    Then An Error Message Appears For An Existing Provider Account Name


### PR DESCRIPTION
This PR adds a new test suite which will be used for test cases with generic use.
The test suite contains a test case where a user tries to import a new provider account with a provider name that already exists.
The PR includes the following:
1. A new test suite file: generic_tests.robot
2. An update to the file: resources/keywords/import_provider_account.resource for adding necesary keywords for the test case
3. An update to the file: resources/object_repo/import_dbaasinventory_obj.resource for adding the relevant web element
[generic_tests_test_case.zip](https://github.com/RHODA-lab/rhoda-ci/files/9017086/generic_tests_test_case.zip)

This PR resolves Jira ticket DBAAS-693