### PR TITLE
[RHODA][UI]Adding a test for a provider account with no instances

### DIFF
--- a/resources/keywords/deploy_instance_dev.resource
+++ b/resources/keywords/deploy_instance_dev.resource
@@ -7,6 +7,7 @@ Resource    ../object_repo/provision_dbinstance_obj.resource
 ${newProject}        ${EMPTY}
 ${instanceName}      ${EMPTY}
 
+
 *** Keywords ***
 User Selects A Project For Database Connection
     Run Keyword If    '${newProject}'=='${EMPTY}'
@@ -142,3 +143,14 @@ User Clicks Continue On Topoloy Binding Instructions
 Update Instance Name With Unique Identifier
     ${instanceUUID}=    Get Element Attribute    ${lnkPanInstance}    innerText
     Set Suite Variable    ${instanceUUID}
+
+User Selects Provider Account With No Instances
+    Wait Until Keyword Succeeds     5x     1s      Wait Until Page Contains Element    ${drpDwnDevProvAccount}
+    Select From List By Label    ${drpDwnDevProvAccount}     ${provaccname}
+
+Text Message For A provider Account With No DB Instances Appears
+    Wait Until Keyword Succeeds     5x     2s      Wait Until Page Contains Element    ${txtNoDBInstExist}
+
+
+
+

--- a/resources/keywords/import_provider_account.resource
+++ b/resources/keywords/import_provider_account.resource
@@ -254,3 +254,4 @@ Provider Account Import Failure Using CLI
 
 Duplicate Provider Account Name Error Message Appears
     Element Should Be Visible    ${lblDuplProvAccName}
+

--- a/resources/object_repo/developer_catalog_obj.resource
+++ b/resources/object_repo/developer_catalog_obj.resource
@@ -46,3 +46,5 @@ ${txtAppPodStatus}              //span[contains(.,"<<appname>>")]//following-sib
 ${btnClosePan}                  //button[@data-test-id="sidebar-close-button"]
 ${txtApplication}               //*[.="<<appname>>"]/parent::*[name()="g"]
 ${lnkAppRoute}                  //h2[.="Routes"]/following::div/a
+${txtNoDBInstExist}             //div[contains(@class,"pf-c-empty-state__content")]
+

--- a/tests/generic_tests.robot
+++ b/tests/generic_tests.robot
@@ -3,7 +3,8 @@ Documentation       Test suite used with generic test cases
 Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
-Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/deploy_instance_dev.resource
+Resource            ../resources/keywords/import_provider_account.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite
@@ -18,3 +19,11 @@ Scenario: Verify Error Message For Duplicate Provider Account Friendly Name
     And User Navigates To Import Database Provider Account Screen From Database Access Page
     And User Enters Data To Import Duplicate CockroachDB Provider Account
     Then Duplicate Provider Account Name Error Message Appears
+
+Scenario: Deploy DBInstances to Topology View When Provider Account Has No Instances
+    [Tags]    smoke   RHOD-84-2
+    When User Imports Valid CockroachDB Provider Account
+    And User Navigates To Add CockroachDB To Topology Screen
+    And User Selects Provider Account With No Instances
+    Then Text Message For A provider Account With No DB Instances Appears
+


### PR DESCRIPTION
This PR adds a test for dealing with a situation where a provider account is created with no instances.

The changes are made in the following files:
resources/keywords/deploy_instance_dev.resource
resources/keywords/import_provider_account.resource
resources/object_repo/developer_catalog_obj.resource
tests/generic_tests.robot

Resolves Jira ticket DBAAS-650