### PR TITLE
Added scripts to provision new mongo DB instances from CLI

### DIFF
--- a/resources/keywords/provision_dbinstance.resource
+++ b/resources/keywords/provision_dbinstance.resource
@@ -107,3 +107,29 @@ DBSC Instance Retrieval Failed On Dev View
     Element Should Be Visible    ${btnTryAgain}
     Element Should Be Visible    ${btnClose}
     Click Button    ${btnClose}
+
+User Provisions New ${databaseProvider} Instance On ${ns_type} Namespace Using OC CLI
+    Provision DB Instance    ${databaseProvider}    ${ns_type}
+
+DB Instance Provisioned Successfully On ${ns_type} Namespace Using OC CLI
+    ${targetNS}     Set Variable    ${newProject}
+    IF  '${ns_type}' == 'Default'
+         ${targetNS}     Set Variable    redhat-dbaas-operator
+    END
+    ${cmd}  Set Variable    oc get DBaaSInstance/${instanceName} -n ${targetNS} -o custom-columns=:.status
+    Wait Until Keyword Succeeds    10x    2s    Instance Available Without Error ${cmd}
+    ${cmd_instance}  Set Variable    oc get DBaaSInstance/${instanceName} -n ${targetNS} -o custom-columns=:.status.instanceID | grep -v '^$'
+    Retrieve Instance ID ${cmd_instance}
+
+Instance Available Without Error ${cmd}
+    ${stdout} =    Execute Command    ${cmd}    True
+    ${stdout_str} =    Convert To String    ${stdout}
+    ${stdout_str} =    Convert To Lower Case    ${stdout_str}
+    Should Contain    ${stdout_str}    type:provisionready
+    Should Not Contain Any    ${stdout_str}     error   notfound
+
+Retrieve Instance ID ${cmd_instance}
+    ${stdout} =    Execute Command    ${cmd_instance}    True
+    ${stdout_str} =    Convert To String    ${stdout}[0]
+    Should Not Contain Any    ${stdout_str}    None
+    Set Suite Variable  ${instanceID}   ${stdout_str}

--- a/tests/mongodb_provision_cli.robot
+++ b/tests/mongodb_provision_cli.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation       Provision and Deploy MongoDB Database Instance from Developer View
+Metadata            Version    0.0.1
+
+Resource            ../resources/keywords/provision_dbinstance.resource
+
+Suite Setup         Set Library Search Order    SeleniumLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given Login To OpenShift CLI
+Test Teardown       Logout Of OpenShift CLI
+
+
+*** Test Cases ***
+Scenario: Provision MongoDB Database Instance On Default Namespace Using OC CLI
+    [Tags]    smoke    RHOD-61-adm
+    When User Provisions New MongoDB Instance On Default Namespace Using OC CLI
+    Then DB Instance Provisioned Successfully On Default Namespace Using OC CLI
+
+Scenario: Provision MongoDB Database Instance On User Defined Namespace Using OC CLI
+    [Tags]    smoke    RHOD-61-dev
+    When User Provisions New MongoDB Instance On User Defined Namespace Using OC CLI
+    Then DB Instance Provisioned Successfully On User Defined Namespace Using OC CLI

--- a/utils/data/oc_dbaas_instance.yaml
+++ b/utils/data/oc_dbaas_instance.yaml
@@ -1,0 +1,12 @@
+apiVersion: dbaas.redhat.com/v1alpha1
+kind: DBaaSInstance
+metadata:
+  name: instance_name
+  namespace: deploy_instance_ns
+spec:
+  name: instance_name
+  inventoryRef:
+    name: provider_account
+    namespace: prov_acc_ns
+  otherInstanceParams:
+    {}


### PR DESCRIPTION
Signed-off-by: Rajan Ravi <rravi@redhat.com>

This PR includes script to Provision a new dbinstance for mongo DB provider from User defined (Developer) and Default (redhat-dbaas-operator) namespaces.

Result -
[rhoda-result.zip](https://github.com/RHODA-lab/rhoda-ci/files/9280454/rhoda-666-2022-08-08-2721.zip)
 