### PR TITLE
Import provider account dev view crdb

### DIFF
--- a/resources/keywords/login.resource
+++ b/resources/keywords/login.resource
@@ -59,5 +59,3 @@ User Closes Welcome Message
     Run Keyword If    ${welcomeTile}
     ...    Click Element    ${btnWelcomTileClose}
 
-Tear Down The Test Suite
-    Log    Test Suite Test Down

--- a/resources/keywords/suite_and_test_teardown.resource
+++ b/resources/keywords/suite_and_test_teardown.resource
@@ -1,0 +1,47 @@
+*** Settings ***
+Library     SeleniumLibrary
+Library     BuiltIn
+Library     String
+Library     OpenShiftLibrary
+Library     ../../utils/scripts/dbaas_utils.py
+Library     ../../utils/scripts/util.py
+Library    OpenShiftCLI
+Resource    ../object_repo/login_obj.resource
+Resource    login.resource
+
+
+*** Keywords ***
+Tear Down The Test Suite
+    Log    Test Suite Test Down
+    Login To OpenShift CLI
+    Remove Existing DBaaSNamespaces
+    Remove Existing DBaaSProviderAccounts
+
+Tear Down The Test
+    Remove Existing DBaaSInstances
+    Logout Of OpenShift CLI
+    Close Browser
+
+Remove Existing DBaaSInstances
+    IF  '${instanceName}' != '${EMPTY}'
+       ${cmd_instances}    Set Variable    oc delete -A DBaaSInstance/${instanceName} -n ${newProject} --wait=true
+       ${stdout} =    Execute Command    ${cmd_instances}    True
+    ELSE
+       Log     No DB Instance ${instanceName} found
+    END
+
+Remove Existing DBaaSNamespaces
+    IF  '${newProject}' != '${EMPTY}'
+       ${cmd_namespaces}   Set Variable    oc delete -A Project/${newProject} --wait=true
+       ${stdout} =    Execute Command    ${cmd_namespaces}    True
+    ELSE
+       Log     No DB Namespace ${newProject} found
+    END
+
+ Remove Existing DBaaSProviderAccounts
+    IF  '${provaccname}' != '${EMPTY}'
+       ${cmd_provider_account} =   Set Variable    oc delete -A DBaaSInventory/${provaccname} -n ${newProject} --wait=true
+       ${stdout} =    Execute Command    ${cmd_provider_account}    True
+    ELSE
+       Log     No DB Provider Account ${provaccname} found
+    END

--- a/tests/cockroachdb_admin_provision.robot
+++ b/tests/cockroachdb_admin_provision.robot
@@ -4,11 +4,11 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
-Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
+Test Teardown       Tear Down The Test
 
 
 *** Test Cases ***

--- a/tests/cockroachdb_dev_provision.robot
+++ b/tests/cockroachdb_dev_provision.robot
@@ -4,11 +4,11 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
-Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
+Test Teardown       Tear Down The Test
 
 
 *** Test Cases ***

--- a/tests/cockroachdb_import_connect.robot
+++ b/tests/cockroachdb_import_connect.robot
@@ -4,11 +4,11 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
 
 
 *** Test Cases ***

--- a/tests/cockroachdb_import_connect.robot
+++ b/tests/cockroachdb_import_connect.robot
@@ -40,3 +40,10 @@ Scenario: Connect CockroachDB DBSC With An Openshift Application
     And User Imports Openshift cockroach Application From YAML
     And User Creates Service Binding Between cockroach DBSC Instance And Imported Openshift Application
     Then The Application Accesses The Connected cockroach Database Instance
+
+Scenario: Import CockroachDB Provider Account From Developer View
+    [Tags]    smoke    RHOD-180
+    When User Navigates To Add CockroachDB Topology Screen From Developer View
+    And User Navigates To Import Provider Account Screen From Developer View
+    And User Enters Data To Import CockroachDB Provider Account
+    Then Provider Account Import Success

--- a/tests/cockroachdb_import_connect_cli.robot
+++ b/tests/cockroachdb_import_connect_cli.robot
@@ -3,11 +3,11 @@ Documentation       To Verify Provisioning of CockroachDB Provider Account and d
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    OpenShiftLibrary
 Suite Teardown      Tear Down The Test Suite
 Test Setup          Given Login To OpenShift CLI
-Test Teardown       Logout Of OpenShift CLI
 
 
 *** Test Cases ***

--- a/tests/crunchydb_admin_provision.robot
+++ b/tests/crunchydb_admin_provision.robot
@@ -4,11 +4,11 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
-Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
+Test Teardown       Tear Down The Test
 
 
 *** Test Cases ***

--- a/tests/crunchydb_dev_provision.robot
+++ b/tests/crunchydb_dev_provision.robot
@@ -4,11 +4,11 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
-Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
+Test Teardown       Tear Down The Test
 
 
 *** Test Cases ***

--- a/tests/crunchydb_import_connect.robot
+++ b/tests/crunchydb_import_connect.robot
@@ -4,11 +4,11 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
 
 
 *** Test Cases ***

--- a/tests/crunchydb_import_connect_cli.robot
+++ b/tests/crunchydb_import_connect_cli.robot
@@ -3,11 +3,11 @@ Documentation       To Verify Provisioning of CrunchyDB Provider Account and dep
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    OpenShiftLibrary
 Suite Teardown      Tear Down The Test Suite
 Test Setup          Given Login To OpenShift CLI
-Test Teardown       Logout Of OpenShift CLI
 
 
 *** Test Cases ***

--- a/tests/generic_tests.robot
+++ b/tests/generic_tests.robot
@@ -5,11 +5,11 @@ Metadata            Version    0.0.1
 Library             SeleniumLibrary
 Resource            ../resources/keywords/deploy_instance_dev.resource
 Resource            ../resources/keywords/import_provider_account.resource
-
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
+Test Teardown       Tear Down The Test
 
 
 *** Test Cases ***

--- a/tests/mongodb_admin_provision.robot
+++ b/tests/mongodb_admin_provision.robot
@@ -4,11 +4,11 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
-Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
+Test Teardown       Tear Down The Test
 
 
 *** Test Cases ***

--- a/tests/mongodb_dev_provision.robot
+++ b/tests/mongodb_dev_provision.robot
@@ -3,11 +3,11 @@ Documentation       Provision and Deploy MongoDB Database Instance from Develope
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
-Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
+Test Teardown       Tear Down The Test
 
 
 *** Test Cases ***

--- a/tests/mongodb_import_connect.robot
+++ b/tests/mongodb_import_connect.robot
@@ -3,11 +3,11 @@ Documentation       To Verify Provisioning of MongoDB Provider Account and deplo
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite
 Test Setup          Given The Browser Is On Openshift Home Screen
-Test Teardown       Close Browser
 
 
 *** Test Cases ***

--- a/tests/mongodb_import_connect_cli.robot
+++ b/tests/mongodb_import_connect_cli.robot
@@ -3,11 +3,11 @@ Documentation       To Verify Provisioning of MongoDB Provider Account and deplo
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    OpenShiftLibrary
 Suite Teardown      Tear Down The Test Suite
 Test Setup          Given Login To OpenShift CLI
-Test Teardown       Logout Of OpenShift CLI
 
 
 *** Test Cases ***


### PR DESCRIPTION
[RHODA][UI] - Adding a test scenario for importing a provider account in developer mode in CockroachDB when no provider accounts exist for this ISV

This PR is adding a test for importing a provider account in developer mode under CockroachDB, when no CockroachDB provider accounts exist.

Resolves Jira ticket DBAAS-695