### PR TITLE
[RHODA][UI] - Add a test for importing an RDS provider account and de…

### DIFF
--- a/resources/keywords/import_provider_account.resource
+++ b/resources/keywords/import_provider_account.resource
@@ -138,6 +138,19 @@ User Enters Invalid Data To Import CockroachDB Provider Account
     Element Should Be Visible    ${btnImportEnabled}
     Click Element    ${btnImportEnabled}
 
+User Enters Data To Import RDS Provider Account
+    [Arguments]    ${isv}=Amazon Relational Database Service
+    set Suite Variable    ${isv}
+    User Enters Provider Account Name And Selects Database Provider
+    Wait Until Page Contains Element    ${txtBxRdsAwsAccsKeyID}    timeout=10s
+    Input Text    ${txtBxRdsAwsAccsKeyID}    ${RDS.awsAccessKeyId}
+    Input Text    ${txtBoxRdsAwsSecKeyID}    ${RDS.awsSecretAccessKeyId}
+    Input Text    ${txtBoxRdsAwsRegion}    ${RDS.awsRegion}
+    Input Text    ${txtBoxAckResrceTags}    ${RESOURCE_TAGS_EMPTY}
+    Input Text    ${txtBoxAckLogLvl}    ${ACK_LOG_LEVEL_EMPTY}
+    Element Should Be Visible    ${btnImportEnabled}
+    Click Element    ${btnImportEnabled}
+
 Provider Account Import Success
     ${no_dbinstance}=    Run Keyword And Return Status    Success Screen For A Provider Account With No DB Instances
     Run Keyword If    ${no_dbinstance}    Run Keywords
@@ -224,6 +237,8 @@ Import ${databaseProvider} Provider Account
     ...    User Enters Data To Import CrunchyDB Provider Account
     ...  ELSE IF    "Cockroach" in """${databaseProvider}"""
     ...    User Enters Data To Import CockroachDB Provider Account
+    ...  ELSE IF    "RDS" in """${databaseProvider}"""
+    ...    User Enters Data To Import RDS Provider Account
     Provider Account Import Success
 
 User Creates ${isv} Secret Credentials
@@ -270,5 +285,4 @@ User Navigates To Import Provider Account Screen From Developer View
     Element Should Be Visible    ${lnkImportProvAcc}
     Click Element    ${lnkImportProvAcc}
     Switch Window   NEW
-
 

--- a/resources/object_repo/import_dbaasinventory_obj.resource
+++ b/resources/object_repo/import_dbaasinventory_obj.resource
@@ -16,6 +16,11 @@ ${txtBxMongoDBPrivAPI}          id:mongodb-atlas-registration-privateApiKey
 ${txtBxCrunchyPubAPI}           id:crunchy-bridge-registration-publicApiKey
 ${txtBxCrunchyPrivAPI}          id:crunchy-bridge-registration-privateApiSecret
 ${txtBxCockroachAPI}            id:cockroachdb-cloud-registration-apiSecretKey
+${txtBxRdsAwsAccsKeyID}         //input[@id='rds-registration-AWS_ACCESS_KEY_ID']
+${txtBoxRdsAwsSecKeyID}         //input[@id='rds-registration-AWS_SECRET_ACCESS_KEY']
+${txtBoxRdsAwsRegion}           //input[@id='rds-registration-AWS_REGION']
+${txtBoxAckResrceTags}          //input[@id='rds-registration-ACK_RESOURCE_TAGS']
+${txtBoxAckLogLvl}              //input[@id='rds-registration-ACK_LOG_LEVEL']
 ${btnImportEnabled}             //button[contains(.,"Import") and @aria-disabled="false"]
 ${btnCreateEnabled}             //button[contains(.,"Create") and @aria-disabled="false"]
 ${lblDBInstSuccess}             //h2[contains(.,"Database instances") and contains(.,"successful")]

--- a/test-variables.yaml.example
+++ b/test-variables.yaml.example
@@ -18,3 +18,8 @@ CRUNCHY:
   privateApiSecret: xxxx
 COCKROACH:
   apiSecretKey: xxxx
+RDS:
+  awsAccessKeyId: xxxx
+  awsSecretAccessKeyId: xxxx
+  awsRegion: xxxx
+

--- a/tests/rds_import_connect.robot
+++ b/tests/rds_import_connect.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Documentation       To Verify Provisioning of RDS Provider Account and deployment of Database Instance
+Metadata            Version    0.0.1
+
+Library             SeleniumLibrary
+Resource            ../resources/keywords/deploy_application.resource
+
+Suite Setup         Set Library Search Order    SeleniumLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given The Browser Is On Openshift Home Screen
+Test Teardown       Close Browser
+
+
+*** Test Cases ***
+Scenario: Import RDS Provider Account From Administrator View
+    [Tags]    smoke    RHOD-300
+    When User Filters Project redhat-dbaas-operator On Project DropDown And Navigates To Database Access Page
+    And User Navigates To Import Database Provider Account Screen From Database Access Page
+    And User Enters Data To Import RDS Provider Account
+    Then Provider Account Import Success
+
+Scenario: Deploy RDS Database Instance
+    [Tags]    smoke   RHOD-301
+    Skip If    "${PREV_TEST_STATUS}" == "FAIL"
+    When User Imports Valid RDS Provider Account
+    And User Navigates To Add RDS To Topology Screen
+    And User Selects Database Instance For The Provider Account
+    Then DBSC Instance Deployed On Developer Topology Graph View
+
+

--- a/utils/scripts/testconfig/test-variables.yaml
+++ b/utils/scripts/testconfig/test-variables.yaml
@@ -17,3 +17,7 @@ CRUNCHY:
   privateApiSecret: PRIVATE_KEY
 COCKROACH:
   apiSecretKey: API_KEY
+RDS:
+  awsAccessKeyId: AWS_ACCESS_KEY_ID
+  awsSecretAccessKeyId: AWS_SECRET_ACCESS_KEY_ID
+  awsRegion: AWS_REGION


### PR DESCRIPTION
…ploying an RDS instance

This PR contains a new test suite which has one test for importing a new RDS provider account.
In addition, there is a second test case for creating and deploying an RDS instance in topology view.

Resolves Jira ticket DBAAS-783
[test_report.html.tar.gz](https://github.com/RHODA-lab/rhoda-ci/files/9307074/test_report.html.tar.gz)
