### PR TITLE
[RHODA][CLI] - Adding tests for provisioning DB instance in CLI for C…

### DIFF
--- a/tests/cockroachdb_provision_cli.robot
+++ b/tests/cockroachdb_provision_cli.robot
@@ -16,3 +16,8 @@ Scenario: Provision CockroachDB Database Instance On Default Namespace Using OC 
     When User Provisions New CockroachDB Instance On Default Namespace Using OC CLI
     Then DB Instance Provisioned Successfully On Default Namespace Using OC CLI
 
+Scenario: Provision CockroachDB Database Instance On User Defined Namespace Using OC CLI
+    [Tags]    smoke    RHOD-262-dev
+    When User Provisions New CockroachDB Instance On User Defined Namespace Using OC CLI
+    Then DB Instance Provisioned Successfully On User Defined Namespace Using OC CLI
+

--- a/tests/crunchydb_provision_cli.robot
+++ b/tests/crunchydb_provision_cli.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Documentation       Provision and Deploy CrunchyDB Database Instance from Developer View
+Metadata            Version    0.0.1
+
+Resource            ../resources/keywords/provision_dbinstance.resource
+
+Suite Setup         Set Library Search Order    SeleniumLibrary
+Suite Teardown      Tear Down The Test Suite
+Test Setup          Given Login To OpenShift CLI
+Test Teardown       Logout Of OpenShift CLI
+
+
+*** Test Cases ***
+Scenario: Provision CrunchyDB Database Instance On Default Namespace Using OC CLI
+    [Tags]    smoke    RHOD-261-adm
+    When User Provisions New CrunchyDB Instance On Default Namespace Using OC CLI
+    Then DB Instance Provisioned Successfully On Default Namespace Using OC CLI
+
+Scenario: Provision CrunchyDB Database Instance On User Defined Namespace Using OC CLI
+    [Tags]    smoke    RHOD-261-dev
+    When User Provisions New CrunchyDB Instance On User Defined Namespace Using OC CLI
+    Then DB Instance Provisioned Successfully On User Defined Namespace Using OC CLI


### PR DESCRIPTION
…runchyDB and CockroachDB

This PR contains:
1. A new CLI test for provisioning a DB instance for CrunchyDB from developer context
2. A new CLI test for provisioning a DB instance for CockroachDB from developer context

This PR resolves Jira ticket DBAAS-676