### PR TITLE
Added test scripts RDS CLI import deploy validation

### DIFF
--- a/resources/keywords/import_provider_account.resource
+++ b/resources/keywords/import_provider_account.resource
@@ -143,9 +143,9 @@ User Enters Data To Import RDS Provider Account
     set Suite Variable    ${isv}
     User Enters Provider Account Name And Selects Database Provider
     Wait Until Page Contains Element    ${txtBxRdsAwsAccsKeyID}    timeout=10s
-    Input Text    ${txtBxRdsAwsAccsKeyID}    ${RDS.awsAccessKeyId}
-    Input Text    ${txtBoxRdsAwsSecKeyID}    ${RDS.awsSecretAccessKeyId}
-    Input Text    ${txtBoxRdsAwsRegion}    ${RDS.awsRegion}
+    Input Text    ${txtBxRdsAwsAccsKeyID}    ${RDS.AWS_ACCESS_KEY_ID}
+    Input Text    ${txtBoxRdsAwsSecKeyID}    ${RDS.AWS_SECRET_ACCESS_KEY}
+    Input Text    ${txtBoxRdsAwsRegion}    ${RDS.AWS_REGION}
     Input Text    ${txtBoxAckResrceTags}    ${RESOURCE_TAGS_EMPTY}
     Input Text    ${txtBoxAckLogLvl}    ${ACK_LOG_LEVEL_EMPTY}
     Element Should Be Visible    ${btnImportEnabled}

--- a/test-variables.yaml.example
+++ b/test-variables.yaml.example
@@ -19,7 +19,7 @@ CRUNCHY:
 COCKROACH:
   apiSecretKey: xxxx
 RDS:
-  awsAccessKeyId: xxxx
-  awsSecretAccessKeyId: xxxx
-  awsRegion: xxxx
+  AWS_ACCESS_KEY_ID: xxxx
+  AWS_SECRET_ACCESS_KEY: xxxx
+  AWS_REGION: xxxx
 

--- a/tests/cockroachdb_provision_cli.robot
+++ b/tests/cockroachdb_provision_cli.robot
@@ -3,6 +3,7 @@ Documentation       Provision and Deploy CockroachDB Database Instance from Deve
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite

--- a/tests/crunchydb_provision_cli.robot
+++ b/tests/crunchydb_provision_cli.robot
@@ -3,6 +3,7 @@ Documentation       Provision and Deploy CrunchyDB Database Instance from Develo
 Metadata            Version    0.0.1
 
 Resource            ../resources/keywords/provision_dbinstance.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite

--- a/tests/rds_import_connect.robot
+++ b/tests/rds_import_connect.robot
@@ -4,6 +4,7 @@ Metadata            Version    0.0.1
 
 Library             SeleniumLibrary
 Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
 
 Suite Setup         Set Library Search Order    SeleniumLibrary
 Suite Teardown      Tear Down The Test Suite

--- a/tests/rds_import_connect_cli.robot
+++ b/tests/rds_import_connect_cli.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Documentation       To Verify Provisioning of RDS Provider Account and deployment of Database Instance Using OC CLI
+Metadata            Version    0.0.1
+
+Resource            ../resources/keywords/deploy_application.resource
+Resource            ../resources/keywords/suite_and_test_teardown.resource
+
+Suite Setup         Set Library Search Order    OpenShiftLibrary
+Test Setup          Given Login To OpenShift CLI
+Test Teardown       Tear Down The Test Suite
+
+
+*** Test Cases ***
+Scenario: Verify Error Message For Invalid Credentials On RDS Using OC CLI
+    [Tags]    smoke    RHOD-510    cli      rds
+    When User Creates RDS Secret With Invalid Credentials
+    And User Imports RDS Provider Account Using CLI
+    Then Provider Account Import Failure Using CLI
+
+Scenario: Import RDS Provider Account Using OC CLI
+    [Tags]    smoke    RHOD-520    cli      rds
+    When User Creates RDS Secret Credentials
+    And User Imports RDS Provider Account Using CLI
+    Then Provider Account Imported Successfully Using CLI
+
+Scenario: Deploy RDS Provider Account Using OC CLI
+    [Tags]    smoke    RHOD-480     cli     rds
+    When User Deploys RDS Instance Using CLI
+    Then DBSC Instance Deployed Successfully Using CLI

--- a/utils/scripts/dbaas_utils.py
+++ b/utils/scripts/dbaas_utils.py
@@ -138,6 +138,9 @@ def create_secret_yaml(isv_lower, valid, namespace):
     elif "cockroach" in isv_lower:
         data["stringData"] = variables["COCKROACH"]
         data["metadata"]["labels"]["db-operator/type"] = "credentials"
+    elif "rds" in isv_lower:
+        data["stringData"] = variables["RDS"]
+        data["metadata"]["labels"]["db-operator/type"] = "credentials"
     if valid == "False":
         last_key = list(data["stringData"].keys())[-1]
         data["stringData"][last_key] = "invalidData"
@@ -172,6 +175,8 @@ def create_provider_account_yaml(isv_lower, namespace):
         data["spec"]["providerRef"]["name"] = "crunchy-bridge-registration"
     elif "cockroach" in isv_lower:
         data["spec"]["providerRef"]["name"] = "cockroachdb-cloud-registration"
+    elif "rds" in isv_lower:
+        data["spec"]["providerRef"]["name"] = "rds-registration"
     return yaml.dump(data, sort_keys=False)
 
 

--- a/utils/scripts/testconfig/test-variables.yaml
+++ b/utils/scripts/testconfig/test-variables.yaml
@@ -18,6 +18,6 @@ CRUNCHY:
 COCKROACH:
   apiSecretKey: API_KEY
 RDS:
-  awsAccessKeyId: AWS_ACCESS_KEY_ID
-  awsSecretAccessKeyId: AWS_SECRET_ACCESS_KEY_ID
-  awsRegion: AWS_REGION
+  AWS_ACCESS_KEY_ID: xxxx
+  AWS_SECRET_ACCESS_KEY: xxxx
+  AWS_REGION: xxxx


### PR DESCRIPTION
Signed-off-by: Rajan Ravi <rravi@redhat.com>
This PR includes the CLI validation for 
- Importing RDS provider account with Valid and Invalid credentials
- Deploying DBSC on Developer topology

JIRA - DBAAS-847
Results - [result.tar.gz](https://github.com/RHODA-lab/rhoda-ci/files/9623364/result.tar.gz)


